### PR TITLE
Use "npm install" istead of "npm run install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A datepicker Vue component. Compatible with Vue 2.x.
 ## [Demo](https://sumcumo.github.io/vue-datepicker/demo/)
 To view demo examples locally:
 - clone the repo
-- run `npm run install && npm run serve`
+- run `npm install && npm run serve`
 
 ## [Documentation](https://sumcumo.github.io/vue-datepicker/)
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -2,7 +2,7 @@
 
 ## Demo
 
-To view demo examples locally, clone the repo and run `npm run install && npm run serve`
+To view demo examples locally, clone the repo and run `npm install && npm run serve`
 
 ## Install
 


### PR DESCRIPTION
The docs says "npm run install", but that is not an existing script. 
I changed it to "npm install".