### PR TITLE
[Docs] Use number modifier to typecast as Number

### DIFF
--- a/docs/.vuepress/components/Demo.vue
+++ b/docs/.vuepress/components/Demo.vue
@@ -147,7 +147,7 @@
         <h5>Settings</h5>
         <div class="form-group">
           <label>Year picker range:</label>
-          <input v-model="yearPickerRange" type="number"/>
+          <input v-model.number="yearPickerRange" type="number"/>
         </div>
         <pre>yearPickerRange: {{ yearPickerRange }}</pre>
       </div>

--- a/example/Demo.vue
+++ b/example/Demo.vue
@@ -324,7 +324,7 @@
         <div class="form-group">
           <label>Year picker range:</label>
           <input
-            v-model="yearPickerRange"
+            v-model.number="yearPickerRange"
             type="number"
           >
         </div>


### PR DESCRIPTION
This PR fixes a small bug in the Demo docs. 

As the `year-picker-range` prop is of type Number, the v-model value has to be typecast to Number using the number modifier, else it will throw the following error:

```
[Vue warn]: Invalid prop: type check failed for prop "yearPickerRange". Expected Number with value 11, got String with value "11".```