### PR TITLE
fix(picker): Next decade button is disabled

### DIFF
--- a/src/components/PickerYear.vue
+++ b/src/components/PickerYear.vue
@@ -56,10 +56,9 @@ export default {
         return false
       }
       const yearFrom = this.utils.getFullYear(this.disabledDates.from)
-      const yearPageDate = this.utils.getFullYear(this.pageDate)
+      const lastCellYear = this.years[this.years.length - 1].year
 
-      return Math.ceil(yearFrom / this.yearRange) * this.yearRange
-        <= Math.ceil(yearPageDate / this.yearRange) * this.yearRange
+      return yearFrom <= lastCellYear
     },
     /**
      * Checks if the previous decade is disabled or not

--- a/test/unit/specs/PickerYear/disabledYears.spec.js
+++ b/test/unit/specs/PickerYear/disabledYears.spec.js
@@ -38,7 +38,7 @@ describe('PickerYear', () => {
 
   it('can\'t change decade when previous or next decades are disabled', () => {
     wrapper.setProps({
-      pageDate: new Date(2016, 9, 15),
+      pageDate: new Date(2010, 9, 1),
       disabledDates: {
         to: new Date(2010, 8, 6),
         from: new Date(2017, 10, 24),
@@ -50,7 +50,7 @@ describe('PickerYear', () => {
 
   it('can change decade despite having a disabled decade', () => {
     wrapper.setProps({
-      pageDate: new Date(2016, 9, 15),
+      pageDate: new Date(2010, 9, 1),
       disabledDates: {
         to: new Date(2000, 11, 19),
         from: new Date(2021, 11, 19),


### PR DESCRIPTION
This fixes a bug where if you add, for example, the following prop: `:disabled-dates="{ from: new Date(2025, 6, 15) }"`, you are erroneously able to click the 'Next' button and reach a page for the '2030-39' decade (that only shows disabled years).