### PR TITLE
Refactor disabled dates

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -104,7 +104,7 @@ import PickerMonth from '~/components/PickerMonth.vue'
 import PickerYear from '~/components/PickerYear.vue'
 import Popup from '~/components/Popup.vue'
 
-const validDate = (val) =>
+const validDate = val =>
   val === null ||
   val instanceof Date ||
   typeof val === 'string' ||
@@ -131,7 +131,7 @@ export default {
     },
     dayCellContent: {
       type: Function,
-      default: (day) => day.date,
+      default: day => day.date,
     },
     disabledDates: {
       type: Object,
@@ -146,7 +146,7 @@ export default {
     fixedPosition: {
       type: String,
       default: '',
-      validator: (val) => {
+      validator: val => {
         const possibleValues = [
           '',
           'bottom',

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -44,7 +44,7 @@ export default {
   props: {
     dayCellContent: {
       type: Function,
-      default: (day) => day.date,
+      default: day => day.date,
     },
     highlighted: {
       type: Object,
@@ -248,7 +248,7 @@ export default {
       }
 
       if (typeof this.highlighted.dates !== 'undefined') {
-        this.highlighted.dates.forEach((d) => {
+        this.highlighted.dates.forEach(d => {
           if (this.utils.compareDates(dateWithoutTime, d)) {
             highlighted = true
           }

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -148,7 +148,7 @@ export default {
      * @return {Boolean}
      */
     isNextDisabled() {
-      if (!this.disabledFromExists) {
+      if (!this.hasDisabledFrom) {
         return false
       }
       return (
@@ -161,7 +161,7 @@ export default {
      * @return {Boolean}
      */
     isPreviousDisabled() {
-      if (!this.disabledToExists) {
+      if (!this.hasDisabledTo) {
         return false
       }
       return (

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -148,15 +148,12 @@ export default {
      * @return {Boolean}
      */
     isNextDisabled() {
-      if (!this.disabledDates || !this.disabledDates.from) {
+      if (!this.disabledFromExists) {
         return false
       }
-      const d = this.pageDate
       return (
-        this.utils.getMonth(this.disabledDates.from) <=
-          this.utils.getMonth(d) &&
-        this.utils.getFullYear(this.disabledDates.from) <=
-          this.utils.getFullYear(d)
+        this.disabledFromMonth <= this.pageMonth &&
+        this.disabledFromYear <= this.pageYear
       )
     },
     /**
@@ -164,14 +161,12 @@ export default {
      * @return {Boolean}
      */
     isPreviousDisabled() {
-      if (!this.disabledDates || !this.disabledDates.to) {
+      if (!this.disabledToExists) {
         return false
       }
-      const d = this.pageDate
       return (
-        this.utils.getMonth(this.disabledDates.to) >= this.utils.getMonth(d) &&
-        this.utils.getFullYear(this.disabledDates.to) >=
-          this.utils.getFullYear(d)
+        this.disabledToMonth >= this.pageMonth &&
+        this.disabledToYear >= this.pageYear
       )
     },
     /**

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -37,30 +37,24 @@ export default {
   mixins: [pickerMixin],
   computed: {
     /**
-     * Checks if the next year is disabled or not
+     * Is the next year disabled?
      * @return {Boolean}
      */
     isNextDisabled() {
-      if (!this.disabledDates || !this.disabledDates.from) {
+      if (!this.disabledFromExists) {
         return false
       }
-      return (
-        this.utils.getFullYear(this.disabledDates.from) <=
-        this.utils.getFullYear(this.pageDate)
-      )
+      return this.disabledFromYear <= this.pageYear
     },
     /**
-     * Checks if the previous year is disabled or not
+     * Is the previous year disabled?
      * @return {Boolean}
      */
     isPreviousDisabled() {
-      if (!this.disabledDates || !this.disabledDates.to) {
+      if (!this.disabledToExists) {
         return false
       }
-      return (
-        this.utils.getFullYear(this.disabledDates.to) >=
-        this.utils.getFullYear(this.pageDate)
-      )
+      return this.disabledToYear >= this.pageYear
     },
     /**
      * Set an array with all months

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -41,7 +41,7 @@ export default {
      * @return {Boolean}
      */
     isNextDisabled() {
-      if (!this.disabledFromExists) {
+      if (!this.hasDisabledFrom) {
         return false
       }
       return this.disabledFromYear <= this.pageYear
@@ -51,7 +51,7 @@ export default {
      * @return {Boolean}
      */
     isPreviousDisabled() {
-      if (!this.disabledToExists) {
+      if (!this.hasDisabledTo) {
         return false
       }
       return this.disabledToYear >= this.pageYear

--- a/src/components/PickerYear.vue
+++ b/src/components/PickerYear.vue
@@ -44,7 +44,7 @@ export default {
      * @return {Boolean}
      */
     isNextDisabled() {
-      if (!this.disabledFromExists) {
+      if (!this.hasDisabledFrom) {
         return false
       }
       return this.disabledFromYear <= this.pageDecadeEnd
@@ -54,7 +54,7 @@ export default {
      * @return {Boolean}
      */
     isPreviousDisabled() {
-      if (!this.disabledToExists) {
+      if (!this.hasDisabledTo) {
         return false
       }
       return this.disabledToYear >= this.pageDecadeStart

--- a/src/components/PickerYear.vue
+++ b/src/components/PickerYear.vue
@@ -40,46 +40,32 @@ export default {
   },
   computed: {
     /**
-     * Checks if the next decade is disabled or not
+     * Is the next decade disabled?
      * @return {Boolean}
      */
     isNextDisabled() {
-      if (!this.disabledDates || !this.disabledDates.from) {
+      if (!this.disabledFromExists) {
         return false
       }
-      const yearFrom = this.utils.getFullYear(this.disabledDates.from)
-      const lastCellYear = this.years[this.years.length - 1].year
-
-      return yearFrom <= lastCellYear
+      return this.disabledFromYear <= this.pageDecadeEnd
     },
     /**
-     * Checks if the previous decade is disabled or not
+     * Is the previous decade disabled?
      * @return {Boolean}
      */
     isPreviousDisabled() {
-      if (!this.disabledDates || !this.disabledDates.to) {
+      if (!this.disabledToExists) {
         return false
       }
-      const yearTo = this.utils.getFullYear(this.disabledDates.to)
-      const yearPageDate = this.utils.getFullYear(this.pageDate)
-
-      return (
-        Math.floor(yearTo / this.yearRange) * this.yearRange >=
-        Math.floor(yearPageDate / this.yearRange) * this.yearRange
-      )
+      return this.disabledToYear >= this.pageDecadeStart
     },
     /**
      * Get decade name on current page.
      * @return {String}
      */
     getPageDecade() {
-      const yearPageDate = this.utils.getFullYear(this.pageDate)
-
-      const decadeStart =
-        Math.floor(yearPageDate / this.yearRange) * this.yearRange
-      const decadeEnd = decadeStart + (this.yearRange - 1)
       const { yearSuffix } = this.translation
-      return `${decadeStart} - ${decadeEnd}${yearSuffix}`
+      return `${this.pageDecadeStart} - ${this.pageDecadeEnd}${yearSuffix}`
     },
     /**
      * Set an array with years for a decade

--- a/src/locale/Language.js
+++ b/src/locale/Language.js
@@ -75,12 +75,12 @@ export default class Language {
   }
 
   getMonthByAbbrName(name) {
-    const monthValue = this._monthsAbbr.findIndex((month) => month === name) + 1
+    const monthValue = this._monthsAbbr.findIndex(month => month === name) + 1
     return monthValue < 10 ? `0${monthValue}` : `${monthValue}`
   }
 
   getMonthByName(name) {
-    const monthValue = this._months.findIndex((month) => month === name) + 1
+    const monthValue = this._months.findIndex(month => month === name) + 1
     return monthValue < 10 ? `0${monthValue}` : `${monthValue}`
   }
 }

--- a/src/mixins/inputProps.vue
+++ b/src/mixins/inputProps.vue
@@ -60,7 +60,7 @@ export default {
     openDate: {
       type: [String, Date, Number],
       default: null,
-      validator: (val) =>
+      validator: val =>
         val === null ||
         val instanceof Date ||
         typeof val === 'string' ||

--- a/src/mixins/pickerMixin.vue
+++ b/src/mixins/pickerMixin.vue
@@ -61,6 +61,56 @@ export default {
       utils: makeDateUtils(this.useUtc),
     }
   },
+  computed: {
+    disabledFromExists() {
+      return this.disabledDates && this.disabledDates.from
+    },
+    disabledFromDay() {
+      return this.disabledFromExists
+        ? this.utils.getDate(this.disabledDates.from)
+        : null
+    },
+    disabledFromMonth() {
+      return this.disabledFromExists
+        ? this.utils.getMonth(this.disabledDates.from)
+        : null
+    },
+    disabledFromYear() {
+      return this.disabledFromExists
+        ? this.utils.getFullYear(this.disabledDates.from)
+        : null
+    },
+    disabledToExists() {
+      return this.disabledDates && this.disabledDates.to
+    },
+    disabledToDay() {
+      return this.disabledToExists
+        ? this.utils.getDate(this.disabledDates.to)
+        : null
+    },
+    disabledToMonth() {
+      return this.disabledToExists
+        ? this.utils.getMonth(this.disabledDates.to)
+        : null
+    },
+    disabledToYear() {
+      return this.disabledToExists
+        ? this.utils.getFullYear(this.disabledDates.to)
+        : null
+    },
+    pageMonth() {
+      return this.utils.getMonth(this.pageDate)
+    },
+    pageYear() {
+      return this.utils.getFullYear(this.pageDate)
+    },
+    pageDecadeStart() {
+      return Math.floor(this.pageYear / this.yearRange) * this.yearRange
+    },
+    pageDecadeEnd() {
+      return this.pageDecadeStart + this.yearRange - 1
+    },
+  },
   methods: {
     /**
      * Emit an event to show the month picker

--- a/src/mixins/pickerMixin.vue
+++ b/src/mixins/pickerMixin.vue
@@ -93,10 +93,10 @@ export default {
         : null
     },
     hasDisabledFrom() {
-      return this.disabledDates && this.disabledDates.from
+      return typeof this.disabledDates.from !== 'undefined'
     },
     hasDisabledTo() {
-      return this.disabledDates && this.disabledDates.to
+      return typeof this.disabledDates.to !== 'undefined'
     },
     pageMonth() {
       return this.utils.getMonth(this.pageDate)

--- a/src/mixins/pickerMixin.vue
+++ b/src/mixins/pickerMixin.vue
@@ -62,41 +62,41 @@ export default {
     }
   },
   computed: {
-    disabledFromExists() {
-      return this.disabledDates && this.disabledDates.from
-    },
     disabledFromDay() {
-      return this.disabledFromExists
+      return this.hasDisabledFrom
         ? this.utils.getDate(this.disabledDates.from)
         : null
     },
     disabledFromMonth() {
-      return this.disabledFromExists
+      return this.hasDisabledFrom
         ? this.utils.getMonth(this.disabledDates.from)
         : null
     },
     disabledFromYear() {
-      return this.disabledFromExists
+      return this.hasDisabledFrom
         ? this.utils.getFullYear(this.disabledDates.from)
         : null
     },
-    disabledToExists() {
-      return this.disabledDates && this.disabledDates.to
-    },
     disabledToDay() {
-      return this.disabledToExists
+      return this.hasDisabledTo
         ? this.utils.getDate(this.disabledDates.to)
         : null
     },
     disabledToMonth() {
-      return this.disabledToExists
+      return this.hasDisabledTo
         ? this.utils.getMonth(this.disabledDates.to)
         : null
     },
     disabledToYear() {
-      return this.disabledToExists
+      return this.hasDisabledTo
         ? this.utils.getFullYear(this.disabledDates.to)
         : null
+    },
+    hasDisabledFrom() {
+      return this.disabledDates && this.disabledDates.from
+    },
+    hasDisabledTo() {
+      return this.disabledDates && this.disabledDates.to
     },
     pageMonth() {
       return this.utils.getMonth(this.pageDate)

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -277,7 +277,7 @@ const utils = {
     }
 
     const REGEX_FORMAT = /y{4}|y{2}|M{1,4}(?![aäe])|d{1,2}|o{1}|E{1}(?![eéi])/g
-    return formatStr.replace(REGEX_FORMAT, (match) => matches[match] || match)
+    return formatStr.replace(REGEX_FORMAT, match => matches[match] || match)
   },
 
   /**
@@ -364,7 +364,7 @@ const utils = {
   },
 }
 
-export const makeDateUtils = (useUtc) => ({
+export const makeDateUtils = useUtc => ({
   ...utils,
   useUtc,
 })

--- a/src/utils/DisabledDatesUtils.js
+++ b/src/utils/DisabledDatesUtils.js
@@ -1,7 +1,7 @@
-const checkForDisabledTo = (disabledDates) => {
+const checkForDisabledTo = disabledDates => {
   return typeof disabledDates.to !== 'undefined' && disabledDates.to
 }
-const checkForDisabledFrom = (disabledDates) => {
+const checkForDisabledFrom = disabledDates => {
   return typeof disabledDates.from !== 'undefined' && disabledDates.from
 }
 const checkDateSpecific = (date, disabledDates, utils) => {

--- a/test/unit/specs/DateUtils.spec.js
+++ b/test/unit/specs/DateUtils.spec.js
@@ -141,7 +141,7 @@ describe('DateUtils', () => {
     const dates = DateUtils.createDateArray(start, end)
     expect(dates.length).toEqual(5)
     let day = 12
-    dates.forEach((date) => {
+    dates.forEach(date => {
       expect(date.getDate()).toEqual(day)
       day += 1
     })
@@ -213,7 +213,7 @@ describe('daysInMonth', () => {
   })
 })
 
-const getAmbiguousDate = (_) => {
+const getAmbiguousDate = _ => {
   const timezoneOffset = new Date().getTimezoneOffset() / 60
   const ambiguousHour = 25 - timezoneOffset
   const ambiguousDate = new Date(2018, 11, 31, ambiguousHour)


### PR DESCRIPTION
`Prettier` has helped to highlight the fact that our `isPreviousDisabled` and `isNextDisabled` computed properties were rather ugly! 

To address this, I have created several small (and easy to understand) computed properties in the `pickerMixin` which allow us to simplify the code in the day/month/year pickers. These small 'building blocks' will also be helpful when cleaning up my keyboard navigation code.

I'll have a go at cleaning up the `highlighted` dates code next. [Edit: I see you've already made a good start...] :-)