### PR TITLE
fix(picker): Make highlighted disabled text blue

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -149,20 +149,23 @@
       color: #104756;
 
       &.disabled {
-        color: #104756;
+        color: #accad2;
       }
     }
 
     &.muted {
       color: #757575;
 
-      &.selected,
-      &.highlighted {
+      &.selected {
         color: #104756;
       }
 
       &.disabled:not(.selected) {
         color: #ddd;
+
+        &.highlighted {
+          color: #accad2;
+        }
       }
     }
 


### PR DESCRIPTION
@MrWook - An easy one!

I noticed that the text colour of highlighted cells remains dark blue even when the cells are disabled - and `includeDisabled: true` is added to the highlighted config. The `muted` text also wasn't quite right. You'll see what I mean with the following:

    <Datepicker
      placeholder="Select Date"
      :inline="true"
      :disabled-dates="{
        customPredictor: (date) => {
          return date.getDate() % 3 === 0
        },
      }"
      :highlighted="{
        days: [0, 1, 2, 3],
        includeDisabled: true,
      }"
    />

Before:
![before](https://user-images.githubusercontent.com/9720120/102333304-24785c00-3f85-11eb-95ea-390e641e65f6.jpg)

After:
![after](https://user-images.githubusercontent.com/9720120/102333317-29d5a680-3f85-11eb-9075-bffc2c4d7942.jpg)
