### PR TITLE
chore(utils): Remove superflous export

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -58,7 +58,7 @@
   </div>
 </template>
 <script>
-import { makeDateUtils } from '~/utils/DateUtils'
+import makeDateUtils from '~/utils/DateUtils'
 import inputProps from '~/mixins/inputProps.vue'
 
 export default {

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -95,7 +95,7 @@
 </template>
 <script>
 import en from '~/locale/translations/en'
-import { makeDateUtils } from '~/utils/DateUtils'
+import makeDateUtils from '~/utils/DateUtils'
 import calendarSlots from '~/utils/calendarSlots'
 import DateInput from '~/components/DateInput.vue'
 import inputProps from '~/mixins/inputProps.vue'

--- a/src/mixins/pickerMixin.vue
+++ b/src/mixins/pickerMixin.vue
@@ -1,6 +1,6 @@
 <script>
 import PickerHeader from '~/components/PickerHeader.vue'
-import { makeDateUtils } from '~/utils/DateUtils'
+import makeDateUtils from '~/utils/DateUtils'
 
 export default {
   components: { PickerHeader },

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -32,6 +32,7 @@ const utils = {
    * @type {Boolean}
    */
   useUtc: false,
+
   /**
    * Returns the full year, using UTC or not
    * @param {Date} date
@@ -364,11 +365,7 @@ const utils = {
   },
 }
 
-export const makeDateUtils = (useUtc) => ({
+export default (useUtc) => ({
   ...utils,
   useUtc,
 })
-
-export default {
-  ...utils,
-}

--- a/test/unit/specs/DateUtils.spec.js
+++ b/test/unit/specs/DateUtils.spec.js
@@ -1,144 +1,146 @@
-import DateUtils, { makeDateUtils } from '~/utils/DateUtils'
+import makeDateUtils from '~/utils/DateUtils'
 import { en } from '~/locale'
 
-describe('DateUtils', () => {
+const dateUtils = makeDateUtils(false)
+
+describe('dateUtils', () => {
   it('should detect invalid date object', () => {
-    expect(DateUtils.isValidDate(null)).toEqual(false)
-    expect(DateUtils.isValidDate(123)).toEqual(false)
-    expect(DateUtils.isValidDate('abc')).toEqual(false)
-    expect(DateUtils.isValidDate({})).toEqual(false)
-    expect(DateUtils.isValidDate(new Date())).toEqual(true)
+    expect(dateUtils.isValidDate(null)).toEqual(false)
+    expect(dateUtils.isValidDate(123)).toEqual(false)
+    expect(dateUtils.isValidDate('abc')).toEqual(false)
+    expect(dateUtils.isValidDate({})).toEqual(false)
+    expect(dateUtils.isValidDate(new Date())).toEqual(true)
   })
 
   it('should give correct days in a month', () => {
-    expect(DateUtils.daysInMonth(2016, 0)).toEqual(31)
-    expect(DateUtils.daysInMonth(2016, 1)).toEqual(29)
-    expect(DateUtils.daysInMonth(2015, 1)).toEqual(28)
-    expect(DateUtils.daysInMonth(2016, 2)).toEqual(31)
-    expect(DateUtils.daysInMonth(2016, 3)).toEqual(30)
-    expect(DateUtils.daysInMonth(2016, 4)).toEqual(31)
-    expect(DateUtils.daysInMonth(2016, 5)).toEqual(30)
-    expect(DateUtils.daysInMonth(2016, 6)).toEqual(31)
-    expect(DateUtils.daysInMonth(2016, 7)).toEqual(31)
-    expect(DateUtils.daysInMonth(2016, 8)).toEqual(30)
-    expect(DateUtils.daysInMonth(2016, 9)).toEqual(31)
-    expect(DateUtils.daysInMonth(2016, 10)).toEqual(30)
-    expect(DateUtils.daysInMonth(2016, 11)).toEqual(31)
+    expect(dateUtils.daysInMonth(2016, 0)).toEqual(31)
+    expect(dateUtils.daysInMonth(2016, 1)).toEqual(29)
+    expect(dateUtils.daysInMonth(2015, 1)).toEqual(28)
+    expect(dateUtils.daysInMonth(2016, 2)).toEqual(31)
+    expect(dateUtils.daysInMonth(2016, 3)).toEqual(30)
+    expect(dateUtils.daysInMonth(2016, 4)).toEqual(31)
+    expect(dateUtils.daysInMonth(2016, 5)).toEqual(30)
+    expect(dateUtils.daysInMonth(2016, 6)).toEqual(31)
+    expect(dateUtils.daysInMonth(2016, 7)).toEqual(31)
+    expect(dateUtils.daysInMonth(2016, 8)).toEqual(30)
+    expect(dateUtils.daysInMonth(2016, 9)).toEqual(31)
+    expect(dateUtils.daysInMonth(2016, 10)).toEqual(30)
+    expect(dateUtils.daysInMonth(2016, 11)).toEqual(31)
   })
 
   it('should format date strings correctly in English', () => {
-    expect(DateUtils.formatDate(new Date(2016, 0, 1), 'd MMMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 0, 1), 'd MMMM yyyy')).toEqual(
       '1 January 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 0, 9), 'dd MMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 0, 9), 'dd MMM yyyy')).toEqual(
       '09 Jan 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 0, 9), 'dd MMM yy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 0, 9), 'dd MMM yy')).toEqual(
       '09 Jan 16',
     )
-    expect(DateUtils.formatDate(new Date(2016, 2, 9), 'yyyy-MM-dd')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 2, 9), 'yyyy-MM-dd')).toEqual(
       '2016-03-09',
     )
-    expect(DateUtils.formatDate(new Date(2016, 2, 9), 'do MMMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 2, 9), 'do MMMM yyyy')).toEqual(
       '9th March 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 2, 1), 'do MMMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 2, 1), 'do MMMM yyyy')).toEqual(
       '1st March 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 2, 2), 'do MMMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 2, 2), 'do MMMM yyyy')).toEqual(
       '2nd March 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 2, 3), 'do MMMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 2, 3), 'do MMMM yyyy')).toEqual(
       '3rd March 2016',
     )
     expect(
-      DateUtils.formatDate(new Date(2016, 7, 1), 'E do MMMM yyyy'),
+      dateUtils.formatDate(new Date(2016, 7, 1), 'E do MMMM yyyy'),
     ).toEqual('Mon 1st August 2016')
     expect(
-      DateUtils.formatDate(new Date(2016, 8, 1), 'E do MMMM yyyy'),
+      dateUtils.formatDate(new Date(2016, 8, 1), 'E do MMMM yyyy'),
     ).toEqual('Thu 1st September 2016')
     expect(
-      DateUtils.formatDate(new Date(2016, 7, 7), 'E do MMMM yyyy'),
+      dateUtils.formatDate(new Date(2016, 7, 7), 'E do MMMM yyyy'),
     ).toEqual('Sun 7th August 2016')
-    expect(DateUtils.formatDate(new Date(2016, 11, 2), 'dd MMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 11, 2), 'dd MMM yyyy')).toEqual(
       '02 Dec 2016',
     )
   })
 
   // issue: https://github.com/sumcumo/vue-datepicker/issues/29
   it('should format date strings without formatting issues like 03 Nrdv 2016 instead of 03 Nov 2016', () => {
-    expect(DateUtils.formatDate(new Date(2016, 0, 12), 'd MMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 0, 12), 'd MMM yyyy')).toEqual(
       '12 Jan 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 1, 12), 'd MMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 1, 12), 'd MMM yyyy')).toEqual(
       '12 Feb 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 2, 12), 'd MMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 2, 12), 'd MMM yyyy')).toEqual(
       '12 Mar 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 3, 12), 'd MMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 3, 12), 'd MMM yyyy')).toEqual(
       '12 Apr 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 4, 12), 'd MMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 4, 12), 'd MMM yyyy')).toEqual(
       '12 May 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 5, 12), 'd MMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 5, 12), 'd MMM yyyy')).toEqual(
       '12 Jun 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 6, 12), 'd MMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 6, 12), 'd MMM yyyy')).toEqual(
       '12 Jul 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 7, 12), 'd MMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 7, 12), 'd MMM yyyy')).toEqual(
       '12 Aug 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 8, 12), 'd MMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 8, 12), 'd MMM yyyy')).toEqual(
       '12 Sep 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 9, 12), 'd MMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 9, 12), 'd MMM yyyy')).toEqual(
       '12 Oct 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 10, 12), 'd MMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 10, 12), 'd MMM yyyy')).toEqual(
       '12 Nov 2016',
     )
-    expect(DateUtils.formatDate(new Date(2016, 11, 12), 'd MMM yyyy')).toEqual(
+    expect(dateUtils.formatDate(new Date(2016, 11, 12), 'd MMM yyyy')).toEqual(
       '12 Dec 2016',
     )
   })
 
   it('should parse english dates', () => {
     expect(
-      DateUtils.parseDate('16 April 2020', 'd MMMM yyyy', en, null),
+      dateUtils.parseDate('16 April 2020', 'd MMMM yyyy', en, null),
     ).toEqual('2020-04-16T00:00:00')
     expect(
-      DateUtils.parseDate('16th Apr 2020', 'do MMM yyyy', en, null),
+      dateUtils.parseDate('16th Apr 2020', 'do MMM yyyy', en, null),
     ).toEqual('2020-04-16T00:00:00')
     expect(
-      DateUtils.parseDate('Thu 16th Apr 2020', 'E do MMM yyyy', en, null),
+      dateUtils.parseDate('Thu 16th Apr 2020', 'E do MMM yyyy', en, null),
     ).toEqual('2020-04-16T00:00:00')
-    expect(DateUtils.parseDate('16.04.2020', 'dd.MM.yyyy', en, null)).toEqual(
+    expect(dateUtils.parseDate('16.04.2020', 'dd.MM.yyyy', en, null)).toEqual(
       '2020-04-16T00:00:00',
     )
-    expect(DateUtils.parseDate('04.16.2020', 'MM.dd.yyyy', en, null)).toEqual(
+    expect(dateUtils.parseDate('04.16.2020', 'MM.dd.yyyy', en, null)).toEqual(
       '2020-04-16T00:00:00',
     )
   })
 
   it('should fail to parse because of missing parser', () => {
     expect(() => {
-      DateUtils.parseDate('16 April 2020', () => {}, en, null)
+      dateUtils.parseDate('16 April 2020', () => {}, en, null)
     }).toThrowError(
       'Parser need to be a function if you are using a custom formatter',
     )
   })
 
   it('should give the correct day', () => {
-    expect(DateUtils.formatDate(new Date(2016, 8, 12), 'E')).toEqual('Mon')
+    expect(dateUtils.formatDate(new Date(2016, 8, 12), 'E')).toEqual('Mon')
   })
 
   it('can create an array of dates', () => {
     const start = new Date(2016, 9, 12)
     const end = new Date(2016, 9, 16)
-    const dates = DateUtils.createDateArray(start, end)
+    const dates = dateUtils.createDateArray(start, end)
     expect(dates.length).toEqual(5)
     let day = 12
     dates.forEach((date) => {
@@ -148,68 +150,68 @@ describe('DateUtils', () => {
   })
 
   it('gives days in a month', () => {
-    expect(DateUtils.daysInMonth(2016, 0)).toEqual(31)
-    expect(DateUtils.daysInMonth(2016, 1)).toEqual(29)
-    expect(DateUtils.daysInMonth(2016, 2)).toEqual(31)
+    expect(dateUtils.daysInMonth(2016, 0)).toEqual(31)
+    expect(dateUtils.daysInMonth(2016, 1)).toEqual(29)
+    expect(dateUtils.daysInMonth(2016, 2)).toEqual(31)
   })
 
   it('getDayNameAbbr moans if date is not a Date object', () => {
-    expect(() => DateUtils.getDayNameAbbr(123, en.months)).toThrow(TypeError)
+    expect(() => dateUtils.getDayNameAbbr(123, en.months)).toThrow(TypeError)
   })
 
   it('getMonthName moans if date is not a Date object', () => {
-    expect(() => DateUtils.getMonthName('string', en.months)).toThrow(TypeError)
+    expect(() => dateUtils.getMonthName('string', en.months)).toThrow(TypeError)
   })
 
   it('getMonthName complains if missing months array', () => {
-    expect(() => DateUtils.getMonthName(new Date())).toThrow(Error)
+    expect(() => dateUtils.getMonthName(new Date())).toThrow(Error)
   })
 
   it('getMonthName accepts a number', () => {
-    expect(DateUtils.getMonthName(3, en.months)).toEqual('April')
+    expect(dateUtils.getMonthName(3, en.months)).toEqual('April')
   })
 
   it('getMonthName accepts a Date object', () => {
-    expect(DateUtils.getMonthName(new Date(2016, 9, 10), en.months)).toEqual(
+    expect(dateUtils.getMonthName(new Date(2016, 9, 10), en.months)).toEqual(
       'October',
     )
   })
 
   it('getMonthNameAbbr moans if date is not a Date object', () => {
-    expect(() => DateUtils.getMonthNameAbbr('abc', en.months)).toThrow(
+    expect(() => dateUtils.getMonthNameAbbr('abc', en.months)).toThrow(
       TypeError,
     )
   })
 
   it('getMonthNameAbbr complains if missing months array', () => {
-    expect(() => DateUtils.getMonthNameAbbr(new Date())).toThrow(Error)
+    expect(() => dateUtils.getMonthNameAbbr(new Date())).toThrow(Error)
   })
 
   it('getMonthNameAbbr accepts a Date object', () => {
     expect(
-      DateUtils.getMonthNameAbbr(new Date(2016, 9, 10), en.monthsAbbr),
+      dateUtils.getMonthNameAbbr(new Date(2016, 9, 10), en.monthsAbbr),
     ).toEqual('Oct')
   })
 
   it('getMonthName accepts a number return a short name', () => {
-    expect(DateUtils.getMonthNameAbbr(3, en.monthsAbbr)).toEqual('Apr')
+    expect(dateUtils.getMonthNameAbbr(3, en.monthsAbbr)).toEqual('Apr')
   })
 })
 
 describe('daysInMonth', () => {
   it('should give the correct days in a month', () => {
-    expect(DateUtils.daysInMonth(2017, 0)).toEqual(31) // Jan
-    expect(DateUtils.daysInMonth(2017, 1)).toEqual(28) // Feb
-    expect(DateUtils.daysInMonth(2017, 2)).toEqual(31) // Mar
-    expect(DateUtils.daysInMonth(2017, 3)).toEqual(30) // Apr
-    expect(DateUtils.daysInMonth(2017, 4)).toEqual(31) // May
-    expect(DateUtils.daysInMonth(2017, 5)).toEqual(30) // Jun
-    expect(DateUtils.daysInMonth(2017, 6)).toEqual(31) // Jul
-    expect(DateUtils.daysInMonth(2017, 7)).toEqual(31) // Aug
-    expect(DateUtils.daysInMonth(2017, 8)).toEqual(30) // Sep
-    expect(DateUtils.daysInMonth(2017, 9)).toEqual(31) // Oct
-    expect(DateUtils.daysInMonth(2017, 10)).toEqual(30) // Nov
-    expect(DateUtils.daysInMonth(2017, 11)).toEqual(31) // Dec
+    expect(dateUtils.daysInMonth(2017, 0)).toEqual(31) // Jan
+    expect(dateUtils.daysInMonth(2017, 1)).toEqual(28) // Feb
+    expect(dateUtils.daysInMonth(2017, 2)).toEqual(31) // Mar
+    expect(dateUtils.daysInMonth(2017, 3)).toEqual(30) // Apr
+    expect(dateUtils.daysInMonth(2017, 4)).toEqual(31) // May
+    expect(dateUtils.daysInMonth(2017, 5)).toEqual(30) // Jun
+    expect(dateUtils.daysInMonth(2017, 6)).toEqual(31) // Jul
+    expect(dateUtils.daysInMonth(2017, 7)).toEqual(31) // Aug
+    expect(dateUtils.daysInMonth(2017, 8)).toEqual(30) // Sep
+    expect(dateUtils.daysInMonth(2017, 9)).toEqual(31) // Oct
+    expect(dateUtils.daysInMonth(2017, 10)).toEqual(30) // Nov
+    expect(dateUtils.daysInMonth(2017, 11)).toEqual(31) // Dec
   })
 })
 
@@ -225,68 +227,68 @@ describe('UTC functions', () => {
 
   it('getFullYear', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.getFullYear(date)).toEqual(date.getFullYear())
+    expect(dateUtils.getFullYear(date)).toEqual(date.getFullYear())
     expect(utcUtils.getFullYear(date)).toEqual(date.getUTCFullYear())
   })
 
   it('getMonth', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.getMonth(date)).toEqual(date.getMonth())
+    expect(dateUtils.getMonth(date)).toEqual(date.getMonth())
     expect(utcUtils.getMonth(date)).toEqual(date.getUTCMonth())
   })
 
   it('getDate', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.getDate(date)).toEqual(date.getDate())
+    expect(dateUtils.getDate(date)).toEqual(date.getDate())
     expect(utcUtils.getDate(date)).toEqual(date.getUTCDate())
   })
 
   it('getDay', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.getDay(date)).toEqual(date.getDay())
+    expect(dateUtils.getDay(date)).toEqual(date.getDay())
     expect(utcUtils.getDay(date)).toEqual(date.getUTCDay())
   })
 
   it('getHours', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.getHours(date)).toEqual(date.getHours())
+    expect(dateUtils.getHours(date)).toEqual(date.getHours())
     expect(utcUtils.getHours(date)).toEqual(date.getUTCHours())
   })
 
   it('getMinutes', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.getMinutes(date)).toEqual(date.getMinutes())
+    expect(dateUtils.getMinutes(date)).toEqual(date.getMinutes())
     expect(utcUtils.getMinutes(date)).toEqual(date.getUTCMinutes())
   })
 
   it('setFullYear', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.setFullYear(date, 2018)).toEqual(date.setFullYear(2018))
+    expect(dateUtils.setFullYear(date, 2018)).toEqual(date.setFullYear(2018))
     expect(utcUtils.setFullYear(date, 2018)).toEqual(date.setUTCFullYear(2018))
   })
 
   it('setMonth', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.setMonth(date, 11)).toEqual(date.setMonth(11))
+    expect(dateUtils.setMonth(date, 11)).toEqual(date.setMonth(11))
     expect(utcUtils.setMonth(date, 11)).toEqual(date.setUTCMonth(11))
   })
 
   it('setDate', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.setDate(date, 31)).toEqual(date.setDate(31))
+    expect(dateUtils.setDate(date, 31)).toEqual(date.setDate(31))
     expect(utcUtils.setDate(date, 31)).toEqual(date.setUTCDate(31))
   })
 
   it('returns the correct day number from an abbreviated day name', () => {
-    expect(DateUtils.getDayFromAbbr('sun')).toEqual(0)
-    expect(DateUtils.getDayFromAbbr('sat')).toEqual(6)
-    expect(() => DateUtils.getDayFromAbbr('nonsense')).toThrow(
+    expect(dateUtils.getDayFromAbbr('sun')).toEqual(0)
+    expect(dateUtils.getDayFromAbbr('sat')).toEqual(6)
+    expect(() => dateUtils.getDayFromAbbr('nonsense')).toThrow(
       'Invalid week day',
     )
   })
 
   it('getTime', () => {
-    expect(DateUtils.getTime()).toEqual('T00:00:00')
+    expect(dateUtils.getTime()).toEqual('T00:00:00')
     expect(utcUtils.getTime()).toEqual('T00:00:00Z')
   })
 })

--- a/test/unit/specs/PickerDay/firstDayOfWeek.spec.js
+++ b/test/unit/specs/PickerDay/firstDayOfWeek.spec.js
@@ -1,9 +1,9 @@
 import { shallowMount } from '@vue/test-utils'
 import PickerDay from '~/components/PickerDay.vue'
 import { en } from '~/locale'
-import { makeDateUtils } from '~/utils/DateUtils'
+import makeDateUtils from '~/utils/DateUtils'
 
-const constructedDateUtils = makeDateUtils(false)
+const dateUtils = makeDateUtils(false)
 
 describe('PickerDay: Set first day of week', () => {
   let wrapper
@@ -32,11 +32,11 @@ describe('PickerDay: Set first day of week', () => {
 
   it('should have 6 days from previous month when month starts on a Sunday', () => {
     const testDate = new Date(2020, 10, 1)
-    const startDate = constructedDateUtils.getNewDateObject(testDate)
+    const startDate = dateUtils.getNewDateObject(testDate)
 
     wrapper.setProps({
       pageDate: testDate,
-      pageTimestamp: constructedDateUtils.setDate(startDate, 1),
+      pageTimestamp: dateUtils.setDate(startDate, 1),
     })
     for (let i = 0; i < 6; i += 1) {
       expect(wrapper.vm.days[i].isPreviousMonth).toBeTruthy()
@@ -46,11 +46,11 @@ describe('PickerDay: Set first day of week', () => {
 
   it('should have no days from previous month when month starts on a Monday', () => {
     const testDate = new Date(2020, 5, 1)
-    const startDate = constructedDateUtils.getNewDateObject(testDate)
+    const startDate = dateUtils.getNewDateObject(testDate)
 
     wrapper.setProps({
       pageDate: testDate,
-      pageTimestamp: constructedDateUtils.setDate(startDate, 1),
+      pageTimestamp: dateUtils.setDate(startDate, 1),
     })
     expect(wrapper.vm.days[0].isPreviousMonth).toBeFalsy()
     expect(wrapper.vm.days[0].isNextMonth).toBeFalsy()
@@ -76,11 +76,11 @@ describe('PickerDay: Datepicker with Saturday as first day of week', () => {
 
   it('should have 6 days from previous month when month starts on a Friday', () => {
     const testDate = new Date(2021, 0, 1)
-    const startDate = constructedDateUtils.getNewDateObject(testDate)
+    const startDate = dateUtils.getNewDateObject(testDate)
 
     wrapper.setProps({
       pageDate: testDate,
-      pageTimestamp: constructedDateUtils.setDate(startDate, 1),
+      pageTimestamp: dateUtils.setDate(startDate, 1),
     })
     for (let i = 0; i < 6; i += 1) {
       expect(wrapper.vm.days[i].isPreviousMonth).toBeTruthy()
@@ -90,11 +90,11 @@ describe('PickerDay: Datepicker with Saturday as first day of week', () => {
 
   it('should have no days from previous month when month starts on a Saturday', () => {
     const testDate = new Date(2020, 7, 1)
-    const startDate = constructedDateUtils.getNewDateObject(testDate)
+    const startDate = dateUtils.getNewDateObject(testDate)
 
     wrapper.setProps({
       pageDate: testDate,
-      pageTimestamp: constructedDateUtils.setDate(startDate, 1),
+      pageTimestamp: dateUtils.setDate(startDate, 1),
     })
     expect(wrapper.vm.days[0].isPreviousMonth).toBeFalsy()
     expect(wrapper.vm.days[0].isNextMonth).toBeFalsy()


### PR DESCRIPTION
This is a very minor (arguably petty!) change to `DateUtils.js' which removes the duplicated export and sets the default export to simply:

    export default (useUtc) => ({
      ...utils,
      useUtc,
    })

It also:
- updates references to `import { makeDateUtils } from '~/utils/DateUtils'` to be `import makeDateUtils from '~/utils/DateUtils'`
- uses camelCase for `dateUtils` in the `DateUtils.spec.js` file (as I believe the convention in JavaScript is to only use PascalCase when referring to a class or component)
- updates `calculatedDateUtils` to the more succinct `dateUtils` in `firstDayOfWeek.spec.js'

I've got too much time on my hands, I know...