### PR TITLE
Fix issue with typeable date on dayless format

### DIFF
--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -5,7 +5,7 @@ const getParsedDate = ({ formatStr, dateStr, translation }) => {
   const splitter = formatStr.match(/-|\/|\s|\./) || ['-']
   const df = formatStr.split(splitter[0])
   const ds = dateStr.split(splitter[0])
-  const ymd = [0, 0, 0]
+  const ymd = [new Date().getFullYear(), '01', '01']
   for (let i = 0; i < df.length; i += 1) {
     if (/yyyy/i.test(df[i])) {
       ymd[0] = ds[i]
@@ -255,8 +255,7 @@ const utils = {
    * @param {Object} translation
    * @return {String}
    */
-  formatDate(date, formatStr, translation) {
-    const translationTemp = !translation ? en : translation
+  formatDate(date, formatStr, translation = en) {
     const year = this.getFullYear(date)
     const month = this.getMonth(date) + 1
     const day = this.getDate(date)
@@ -266,15 +265,12 @@ const utils = {
       d: day,
       yyyy: year,
       yy: String(year).slice(2),
-      MMMM: this.getMonthName(this.getMonth(date), translationTemp.months),
-      MMM: this.getMonthNameAbbr(
-        this.getMonth(date),
-        translationTemp.monthsAbbr,
-      ),
+      MMMM: this.getMonthName(this.getMonth(date), translation.months),
+      MMM: this.getMonthNameAbbr(this.getMonth(date), translation.monthsAbbr),
       MM: `0${month}`.slice(-2),
       M: month,
       o: this.getNthSuffix(this.getDate(date)),
-      E: this.getDayNameAbbr(date, translationTemp.days),
+      E: this.getDayNameAbbr(date, translation.days),
     }
 
     const REGEX_FORMAT = /y{4}|y{2}|M{1,4}(?![aäe])|d{1,2}|o{1}|E{1}(?![eéi])/g
@@ -291,7 +287,7 @@ const utils = {
    * @return {Date | String}
    */
   // eslint-disable-next-line max-params,complexity,max-statements
-  parseDate(dateStr, formatStr, translation, parser) {
+  parseDate(dateStr, formatStr, translation = en, parser = null) {
     if (!(dateStr && formatStr)) {
       return dateStr
     }
@@ -306,7 +302,7 @@ const utils = {
     const ymd = getParsedDate({
       formatStr,
       dateStr,
-      translation: !translation ? en : translation,
+      translation,
     })
 
     const dat = `${ymd.join('-')}${this.getTime()}`

--- a/test/unit/specs/DateUtils.spec.js
+++ b/test/unit/specs/DateUtils.spec.js
@@ -108,28 +108,47 @@ describe('dateUtils', () => {
   })
 
   it('should parse english dates', () => {
-    expect(
-      dateUtils.parseDate('16 April 2020', 'd MMMM yyyy', en, null),
-    ).toEqual('2020-04-16T00:00:00')
-    expect(
-      dateUtils.parseDate('16th Apr 2020', 'do MMM yyyy', en, null),
-    ).toEqual('2020-04-16T00:00:00')
-    expect(
-      dateUtils.parseDate('Thu 16th Apr 2020', 'E do MMM yyyy', en, null),
-    ).toEqual('2020-04-16T00:00:00')
-    expect(dateUtils.parseDate('16.04.2020', 'dd.MM.yyyy', en, null)).toEqual(
+    expect(dateUtils.parseDate('16 April 2020', 'd MMMM yyyy')).toEqual(
       '2020-04-16T00:00:00',
     )
-    expect(dateUtils.parseDate('04.16.2020', 'MM.dd.yyyy', en, null)).toEqual(
+    expect(dateUtils.parseDate('16th Apr 2020', 'do MMM yyyy')).toEqual(
+      '2020-04-16T00:00:00',
+    )
+    expect(dateUtils.parseDate('Thu 16th Apr 2020', 'E do MMM yyyy')).toEqual(
+      '2020-04-16T00:00:00',
+    )
+    expect(dateUtils.parseDate('16.04.2020', 'dd.MM.yyyy')).toEqual(
+      '2020-04-16T00:00:00',
+    )
+    expect(dateUtils.parseDate('04.16.2020', 'MM.dd.yyyy')).toEqual(
       '2020-04-16T00:00:00',
     )
   })
 
   it('should fail to parse because of missing parser', () => {
     expect(() => {
-      dateUtils.parseDate('16 April 2020', () => {}, en, null)
+      dateUtils.parseDate('16 April 2020', () => {})
     }).toThrowError(
       'Parser need to be a function if you are using a custom formatter',
+    )
+  })
+
+  it('should parse formats without day', () => {
+    expect(dateUtils.parseDate('April 2020', 'MMMM yyyy')).toEqual(
+      '2020-04-01T00:00:00',
+    )
+  })
+
+  it('should parse formats without month', () => {
+    expect(dateUtils.parseDate('15 2020', 'dd yyyy')).toEqual(
+      '2020-01-15T00:00:00',
+    )
+  })
+
+  it('should parse formats without year', () => {
+    const currentYear = new Date().getFullYear()
+    expect(dateUtils.parseDate('15 April', 'dd MMMM')).toEqual(
+      `${currentYear}-04-15T00:00:00`,
     )
   })
 


### PR DESCRIPTION
resolves https://github.com/sumcumo/vue-datepicker/issues/68

Safari/Firefox could not handle typeable dates with a format without a day/month/year