### PR TITLE
Consistent naming of page title variables

### DIFF
--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -11,8 +11,7 @@
         class="day__month_btn"
         @click="showPickerCalendar('month')"
       >
-        {{ isYmd ? currYearName : currMonthName }}
-        {{ isYmd ? currMonthName : currYearName }}
+        {{ pageTitleDay }}
       </span>
       <slot slot="nextIntervalBtn" name="nextIntervalBtn" />
       <slot slot="prevIntervalBtn" name="prevIntervalBtn" />
@@ -169,19 +168,25 @@ export default {
       )
     },
     /**
-     * Is this translation using year/month/day format?
-     * @return {Boolean}
-     */
-    isYmd() {
-      return this.translation.ymd && this.translation.ymd === true
-    },
-    /**
      * Returns the current page's month as an integer.
      * @return {Number}
      */
     pageMonth() {
       return this.utils.getMonth(this.pageDate)
     },
+    /**
+     * Display the current page's month & year as the title.
+     * @return {String}
+     */
+    pageTitleDay() {
+      return this.translation.ymd
+        ? `${this.currYearName} ${this.currMonthName}`
+        : `${this.currMonthName} ${this.currYearName}`
+    },
+    /**
+     * The first day of the next page's month.
+     * @return {Date}
+     */
     nextPageDate() {
       const d = new Date(this.pageTimestamp)
       return new Date(this.utils.setMonth(d, this.utils.getMonth(d) + 1))

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -11,7 +11,7 @@
         :class="allowedToShowView('year') ? 'up' : ''"
         @click="showPickerCalendar('year')"
       >
-        {{ pageYearName }}
+        {{ pageTitleMonth }}
       </span>
       <slot slot="nextIntervalBtn" name="nextIntervalBtn" />
       <slot slot="prevIntervalBtn" name="prevIntervalBtn" />
@@ -85,10 +85,10 @@ export default {
       return months
     },
     /**
-     * Get year name on current page.
+     * Display the current page's year as the title.
      * @return {String}
      */
-    pageYearName() {
+    pageTitleMonth() {
       const { yearSuffix } = this.translation
       return `${this.pageYear}${yearSuffix}`
     },

--- a/src/components/PickerYear.vue
+++ b/src/components/PickerYear.vue
@@ -7,7 +7,7 @@
       :previous="previousDecade"
     >
       <span>
-        {{ getPageDecade }}
+        {{ pageTitleYear }}
       </span>
       <slot slot="nextIntervalBtn" name="nextIntervalBtn" />
       <slot slot="prevIntervalBtn" name="prevIntervalBtn" />
@@ -74,10 +74,10 @@ export default {
       return this.pageDecadeStart + this.yearRange - 1
     },
     /**
-     * Get decade name on current page.
+     * Display the current page's decade (or year range) as the title.
      * @return {String}
      */
-    getPageDecade() {
+    pageTitleYear() {
       const { yearSuffix } = this.translation
       return `${this.pageDecadeStart} - ${this.pageDecadeEnd}${yearSuffix}`
     },
@@ -134,7 +134,6 @@ export default {
         date,
       )
     },
-    // eslint-disable-next-line complexity,max-statements
     /**
      * Whether the selected date is in this year
      * @param {Date} date

--- a/test/unit/specs/PickerYear/pickerYear.spec.js
+++ b/test/unit/specs/PickerYear/pickerYear.spec.js
@@ -44,12 +44,12 @@ describe('PickerYear', () => {
       pageDate: new Date(2021, 1, 1),
     })
     await wrapper.vm.$nextTick()
-    expect(wrapper.vm.getPageDecade).toEqual('2020 - 2029')
+    expect(wrapper.vm.pageTitleYear).toEqual('2020 - 2029')
     wrapper.setProps({
       pageDate: new Date(2001, 1, 1),
     })
     await wrapper.vm.$nextTick()
-    expect(wrapper.vm.getPageDecade).toEqual('2000 - 2009')
+    expect(wrapper.vm.pageTitleYear).toEqual('2000 - 2009')
   })
 
   it('emits an event when selected', () => {
@@ -63,7 +63,7 @@ describe('PickerYear', () => {
       yearRange: 12,
     })
     await wrapper.vm.$nextTick()
-    expect(wrapper.vm.getPageDecade).toEqual('2016 - 2027')
+    expect(wrapper.vm.pageTitleYear).toEqual('2016 - 2027')
     expect(wrapper.vm.$el.querySelectorAll('.cell.year').length).toEqual(12)
   })
 })


### PR DESCRIPTION
This is a simple refactor of the page title text which appears at the top of the picker (between the `prev` and `next` buttons). The amended version removes inconsistencies in the naming of these variables by using the following computed properties:

- pageTitleDay
- pageTitleMonth
- pageTitleYear