### PR TITLE
Highlight today

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -19,6 +19,10 @@
   width: 300px;
   z-index: 10000;
 
+  .today {
+    background-color: #eee;
+  }
+
   * {
     box-sizing: border-box;
   }


### PR DESCRIPTION
Like in https://github.com/sumcumo/vue-datepicker/issues/64 mentioned there was a today class that was never used or referenced.
Now it is styled by default