### PR TITLE
Resolve flicker on showCalendarByFocus

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -92,7 +92,8 @@ export default {
     const constructedDateUtils = makeDateUtils(this.useUtc)
     return {
       input: null,
-      isFocusedUsed: false,
+      inputFocusOpensCalendar: true,
+      isInputFocused: false,
       typedDate: '',
       utils: constructedDateUtils,
     }
@@ -130,6 +131,13 @@ export default {
     resetTypedDate() {
       this.typedDate = ''
     },
+    isInputFocused: {
+      immediate: true,
+      handler() {
+        this.setInputIsFocused()
+        this.setInputFocusOpensCalendar()
+      },
+    },
   },
   mounted() {
     this.input = this.$el.querySelector('input')
@@ -148,9 +156,10 @@ export default {
       if (this.typeable) {
         this.submitTypedDate()
       }
+
       this.$emit('blur')
+      this.setInputIsFocused()
       this.$emit('close-calendar')
-      this.isFocusedUsed = false
     },
     /**
      * Attempt to parse a typed date
@@ -184,23 +193,26 @@ export default {
         this.parser,
       )
     },
-    toggleCalendar() {
-      this.$emit(this.isOpen ? 'close-calendar' : 'show-calendar')
+    setInputIsFocused() {
+      const input = this.$refs[this.refName]
+
+      if (input) {
+        this.isInputFocused = input.matches(':focus')
+      }
+    },
+    setInputFocusOpensCalendar() {
+      this.inputFocusOpensCalendar =
+        !this.showCalendarOnButtonClick &&
+        (this.showCalendarOnFocus ||
+          (!this.showCalendarOnFocus && !this.isInputFocused))
     },
     showCalendarByClick() {
-      const isFocusedUsed =
-        !this.showCalendarOnFocus ||
-        (this.showCalendarOnFocus && !this.isFocusedUsed)
-      if (!this.showCalendarOnButtonClick && !isFocusedUsed) {
-        this.toggleCalendar()
-      }
-
-      if (this.showCalendarOnFocus) {
-        this.isFocusedUsed = true
+      if (this.inputFocusOpensCalendar && !this.isOpen) {
+        this.$emit('show-calendar')
       }
     },
     showCalendarByFocus() {
-      if (this.showCalendarOnFocus) {
+      if (this.showCalendarOnFocus && this.inputFocusOpensCalendar) {
         this.$emit('show-calendar')
       }
 
@@ -220,6 +232,9 @@ export default {
         this.typedDate = ''
         this.$emit('typed-date', parsedDate)
       }
+    },
+    toggleCalendar() {
+      this.$emit(this.isOpen ? 'close-calendar' : 'show-calendar')
     },
   },
 }

--- a/test/unit/specs/DateInput/DateInput.spec.js
+++ b/test/unit/specs/DateInput/DateInput.spec.js
@@ -117,8 +117,8 @@ describe('DateInput', () => {
     expect(wrapper.find('input').element.value).toEqual('!')
   })
 
-  it('triggers closeCalendar on blur', () => {
-    wrapper.find('input').trigger('blur')
+  it('triggers closeCalendar on blur', async () => {
+    await wrapper.find('input').trigger('blur')
     expect(wrapper.emitted('close-calendar')).toBeTruthy()
   })
 
@@ -140,12 +140,15 @@ describe('DateInput', () => {
   })
 
   it('should open the calendar only on calendar button click', async () => {
-    wrapper.setProps({
+    await wrapper.setProps({
       calendarButton: true,
       showCalendarOnButtonClick: true,
     })
-    await wrapper.vm.$nextTick()
-    wrapper.find('input').trigger('click')
+    await wrapper.vm.setInputFocusOpensCalendar()
+
+    const input = wrapper.find('input')
+    await input.trigger('focus')
+    await input.trigger('click')
     expect(wrapper.emitted('show-calendar')).toBeFalsy()
     wrapper.find('.vdp-datepicker__calendar-button').trigger('click')
     expect(wrapper.emitted('show-calendar')).toBeTruthy()

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -51,18 +51,60 @@ describe('Datepicker mounted', () => {
     expect(wrapper.emitted().focus).toBeTruthy()
   })
 
-  it('should open the calendar with click on input with showCalendarOnFocus', async () => {
-    wrapper.setProps({
+  it('should open the calendar with click on input when showCalendarOnFocus = true', async () => {
+    await wrapper.setProps({
       showCalendarOnFocus: true,
     })
-    await wrapper.vm.$nextTick()
-    wrapper.find('input').trigger('focus')
-    await wrapper.vm.$nextTick()
-    wrapper.find('input').trigger('click')
-    await wrapper.vm.$nextTick()
-    wrapper.find('input').trigger('FUCK')
-    expect(wrapper.emitted('opened')).toBeTruthy()
-    expect(wrapper.emitted('closed')).toBeFalsy()
+    const input = wrapper.find('input')
+
+    await input.trigger('click')
+    expect(wrapper.vm.isOpen).toBeTruthy()
+  })
+
+  it('should toggle the calendar via the calendar button', async () => {
+    await wrapper.setProps({
+      calendarButton: true,
+    })
+
+    const calendarButton = wrapper.find('span.vdp-datepicker__calendar-button')
+
+    await calendarButton.trigger('click')
+    expect(wrapper.vm.isOpen).toBeTruthy()
+
+    await calendarButton.trigger('click')
+    expect(wrapper.vm.isOpen).toBeFalsy()
+  })
+
+  it('should toggle the calendar via the calendar button when showCalendarOnFocus = true', async () => {
+    await wrapper.setProps({
+      calendarButton: true,
+      showCalendarOnFocus: true,
+    })
+
+    const calendarButton = wrapper.find('span.vdp-datepicker__calendar-button')
+
+    await calendarButton.trigger('click')
+    expect(wrapper.vm.isOpen).toBeTruthy()
+
+    await calendarButton.trigger('click')
+    expect(wrapper.vm.isOpen).toBeFalsy()
+  })
+
+  it.skip('should close the calendar via the calendar button, despite input being focused', async () => {
+    await wrapper.setProps({
+      calendarButton: true,
+      showCalendarOnFocus: true,
+    })
+
+    const input = wrapper.find('input')
+    const calendarButton = wrapper.find('span.vdp-datepicker__calendar-button')
+
+    await input.trigger('focus')
+    expect(wrapper.vm.isOpen).toBeTruthy()
+
+    await input.trigger('blur')
+    await calendarButton.trigger('click')
+    expect(wrapper.vm.isOpen).toBeFalsy()
   })
 })
 


### PR DESCRIPTION
Not sure if this is of much help? 

I've managed to get rid of the flicker, but now when `calendar-button="true"` (and the `input` is focused), the calendar closes and opens again when you click on the calendar button...