### PR TITLE
Trap focus

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -9,7 +9,7 @@
         'calendar-btn-disabled': disabled,
       }"
       class="vdp-datepicker__calendar-button"
-      @click="toggleCalendar"
+      @click="toggleTrapCalendar"
     >
       <span :class="{ 'input-group-text': bootstrapStyling }">
         <slot name="calendarBtn">
@@ -64,10 +64,11 @@
 <script>
 import makeDateUtils from '~/utils/DateUtils'
 import inputProps from '~/mixins/inputProps.vue'
+import trapFocus from '~/mixins/trapFocus.vue'
 
 export default {
   name: 'DateInput',
-  mixins: [inputProps],
+  mixins: [inputProps, trapFocus],
   props: {
     isOpen: {
       type: Boolean,
@@ -226,6 +227,14 @@ export default {
         return
       }
       this.$emit(this.isOpen ? 'close-calendar' : 'show-calendar')
+    },
+    toggleTrapCalendar() {
+      this.toggleCalendar()
+      if (!this.isOpen) {
+        this.$nextTick().then(() => {
+          this.trapFocus(this.$parent.$refs.popup.$el)
+        })
+      }
     },
   },
 }

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -2,7 +2,7 @@
   <div :class="{ 'input-group': bootstrapStyling }">
     <slot name="beforeDateInput" />
     <!-- Calendar Button -->
-    <span
+    <button
       v-if="calendarButton"
       :class="{
         'input-group-prepend': bootstrapStyling,
@@ -19,7 +19,7 @@
           </i>
         </slot>
       </span>
-    </span>
+    </button>
     <!-- Input -->
     <input
       :id="id"

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -1,5 +1,9 @@
 <template>
-  <div :class="[wrapperClass, isRtl ? 'rtl' : '']" class="vdp-datepicker" @keyup.escape="close()">
+  <div
+    :class="[wrapperClass, isRtl ? 'rtl' : '']"
+    class="vdp-datepicker"
+    @keyup.escape="close()"
+  >
     <DateInput
       :id="id"
       :autofocus="autofocus"

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="[wrapperClass, isRtl ? 'rtl' : '']" class="vdp-datepicker">
+  <div :class="[wrapperClass, isRtl ? 'rtl' : '']" class="vdp-datepicker" @keyup.escape="close()">
     <DateInput
       :id="id"
       :autofocus="autofocus"

--- a/src/mixins/trapFocus.vue
+++ b/src/mixins/trapFocus.vue
@@ -1,0 +1,63 @@
+<script>
+export default {
+  name: 'trapFocus',
+  data() {
+    return {
+      fistFocusable: null,
+      focusableElements: null,
+      lastFocusable: null,
+      trappedElement: null,
+    }
+  },
+  methods: {
+    findFocusable(el) {
+      return el.querySelectorAll(
+        'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, [tabindex="0"], [contenteditable]',
+      )
+    },
+    keyboardHandler(e) {
+      if (e.key === 'Tab' || e.code === 'Tab') {
+        if (e.shiftKey && document.activeElement === this.fistFocusable) {
+          e.preventDefault()
+          this.lastFocusable.focus()
+        } else if (
+          !e.shiftKey &&
+          document.activeElement === this.lastFocusable
+        ) {
+          e.preventDefault()
+          this.fistFocusable.focus()
+        }
+      }
+    },
+    trapFocus(target = null) {
+      this.$nextTick().then(() => {
+        if (target) {
+          this.focusableElements = this.findFocusable(target)
+
+          if (this.focusableElements.length > 0) {
+            this.fistFocusable = this.focusableElements[0]
+            this.lastFocusable = this.focusableElements[
+              this.focusableElements.length - 1
+            ]
+            this.fistFocusable.focus()
+
+            this.trappedElement = target
+            this.trappedElement.addEventListener(
+              'keydown',
+              this.keyboardHandler,
+            )
+          }
+        }
+        if (!target) {
+          if (this.trappedElement) {
+            this.trappedElement.removeEventListener(
+              'keydown',
+              this.keyboardHandler,
+            )
+          }
+        }
+      })
+    },
+  },
+}
+</script>

--- a/src/mixins/trapFocus.vue
+++ b/src/mixins/trapFocus.vue
@@ -1,6 +1,6 @@
 <script>
 export default {
-  name: 'trapFocus',
+  name: 'TrapFocus',
   data() {
     return {
       fistFocusable: null,

--- a/src/mixins/trapFocus.vue
+++ b/src/mixins/trapFocus.vue
@@ -35,7 +35,7 @@ export default {
           this.focusableElements = this.findFocusable(target)
 
           if (this.focusableElements.length > 0) {
-            this.fistFocusable = this.focusableElements[0]
+            [this.fistFocusable] = this.focusableElements
             this.lastFocusable = this.focusableElements[
               this.focusableElements.length - 1
             ]

--- a/src/mixins/trapFocus.vue
+++ b/src/mixins/trapFocus.vue
@@ -20,20 +20,17 @@ export default {
         if (e.shiftKey && document.activeElement === this.fistFocusable) {
           e.preventDefault()
           this.lastFocusable.focus()
-        } else if (
-          !e.shiftKey &&
-          document.activeElement === this.lastFocusable
-        ) {
+        }
+        if (!e.shiftKey && document.activeElement === this.lastFocusable) {
           e.preventDefault()
           this.fistFocusable.focus()
         }
       }
     },
     trapFocus(target = null) {
-      this.$nextTick().then(() => {
+      this.$nextTick(function () {
         if (target) {
           this.focusableElements = this.findFocusable(target)
-
           if (this.focusableElements.length > 0) {
             [this.fistFocusable] = this.focusableElements
             this.lastFocusable = this.focusableElements[
@@ -48,13 +45,11 @@ export default {
             )
           }
         }
-        if (!target) {
-          if (this.trappedElement) {
-            this.trappedElement.removeEventListener(
-              'keydown',
-              this.keyboardHandler,
-            )
-          }
+        if (!target && this.trappedElement) {
+          this.trappedElement.removeEventListener(
+            'keydown',
+            this.keyboardHandler,
+          )
         }
       })
     },


### PR DESCRIPTION
- Adds support closing the popup with the escape key
- Implements focus trapping when the calendar button is used to open the popup

Please note that much of this depends on #81 as focus trapping is an element of keyboard accessibility. 