### PR TITLE
Rename `setDate` to `selectDate` in Datepicker.vue

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -367,7 +367,7 @@ export default {
       }
 
       this.resetTypedDate = this.utils.getNewDateObject()
-      this.setDate(cell.timestamp)
+      this.selectDate(cell.timestamp)
       this.close()
     },
     /**
@@ -380,7 +380,7 @@ export default {
      * Set the date from a 'typed-date' event
      */
     handleTypedDate(date) {
-      this.setDate(date.valueOf())
+      this.selectDate(date.valueOf())
     },
     /**
      * Initiate the component
@@ -444,10 +444,10 @@ export default {
       this.setPageDate(this.selectedDate)
     },
     /**
-     * Set the selected date
+     * Select the date
      * @param {Number} timestamp
      */
-    setDate(timestamp) {
+    selectDate(timestamp) {
       const date = new Date(timestamp)
       this.selectedDate = date
       this.setPageDate(date)

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -152,14 +152,14 @@ describe('Datepicker mount', () => {
   })
 
   it('shows the correct month as you type', async () => {
-    const spySetDate = jest.spyOn(wrapper.vm, 'setDate')
+    const spySelectDate = jest.spyOn(wrapper.vm, 'selectDate')
     const input = wrapper.find('input')
 
     await input.trigger('click')
     input.element.value = 'Jan'
     await input.trigger('keyup')
 
-    expect(spySetDate).toHaveBeenCalled()
+    expect(spySelectDate).toHaveBeenCalled()
     expect(wrapper.vm.isOpen).toBeTruthy()
     expect(new Date(wrapper.vm.pageDate).getMonth()).toBe(0)
 

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -173,14 +173,14 @@ describe('Datepicker shallowMounted', () => {
         format: 'yyyy-MM-dd',
       },
     })
-    wrapperTemp.vm.setDate(dateTemp.valueOf())
+    wrapperTemp.vm.selectDate(dateTemp.valueOf())
     expect(wrapperTemp.vm.selectedDate.valueOf()).toEqual(dateTemp.valueOf())
   })
 
   it('clears the date', () => {
     const dateTemp = new Date(2016, 9, 9)
     const wrapperTemp = shallowMount(Datepicker)
-    wrapperTemp.vm.setDate(dateTemp.valueOf())
+    wrapperTemp.vm.selectDate(dateTemp.valueOf())
     wrapperTemp.vm.clearDate()
     expect(wrapperTemp.vm.selectedDate).toEqual(null)
   })
@@ -280,7 +280,7 @@ describe('Datepicker shallowMounted', () => {
     expect(wrapperTemp.vm.pageDate.getFullYear()).toEqual(today.getFullYear())
     expect(wrapperTemp.vm.pageDate.getMonth()).toEqual(today.getMonth())
     expect(wrapperTemp.vm.pageDate.getDate()).toEqual(1)
-    wrapperTemp.vm.setDate(pastDate.valueOf())
+    wrapperTemp.vm.selectDate(pastDate.valueOf())
     wrapperTemp.vm.resetDefaultPageDate()
     expect(wrapperTemp.vm.pageDate.getFullYear()).toEqual(
       pastDate.getFullYear(),


### PR DESCRIPTION
A very minor change, but it:
- helps to distinguish it from the eponymous method in `utils`
- uses the same language as the `selectedDate` data property in Datepicker.vue (which this method sets).