### PR TITLE
Inline class causes issues with use of TailwindCSS

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -283,7 +283,7 @@ export default {
     pickerClasses() {
       return [
         this.calendarClass,
-        this.isInline && 'inline',
+        this.isInline && 'vdp-datepicker__calendar--inline',
         this.isRtl && this.appendToBody && 'rtl',
       ]
     },

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -27,7 +27,7 @@
     box-sizing: border-box;
   }
 
-  &.inline {
+  &.vdp-datepicker__calendar--inline {
     position: static;
   }
 


### PR DESCRIPTION
We are using the datepicker alongside TailwindCSS in a project, the problem that arises is that when we are using an inline datepicker the class `inline` is added to the HTML-element. TailwindCSS uses the `inline` class as an utility class to apply

```
display: inline;
```
This is causing the lay-out to be incorrect, causing it to look something like this:

![image](https://user-images.githubusercontent.com/6427451/119134836-ef919900-ba3d-11eb-85c7-7c82693fb9c3.png)
