### PR TITLE
Only highlight selected edge date if shown

### DIFF
--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -225,9 +225,12 @@ export default {
      * @param {Object} day
      * @return {Object}
      */
+    // eslint-disable-next-line complexity
     dayClasses(day) {
       return {
-        'selected': day.isSelected,
+        'selected': this.showEdgeDates
+          ? day.isSelected
+          : day.isSelected && !day.isPreviousMonth && !day.isNextMonth,
         'disabled': day.isDisabled,
         'highlighted': day.isHighlighted,
         'muted': day.isPreviousMonth || day.isNextMonth,

--- a/test/unit/specs/PickerDay/pickerDay.spec.js
+++ b/test/unit/specs/PickerDay/pickerDay.spec.js
@@ -102,4 +102,54 @@ describe('PickerDay: DOM', () => {
 
     expect(wrapper.emitted('select')[0][0].date).toBe(3)
   })
+
+  it("only highlights today's edge date if shown", async () => {
+    const day = {
+      date: 1,
+      isToday: true,
+      isPreviousMonth: false,
+      isNextMonth: true,
+    }
+
+    await wrapper.setProps({
+      showEdgeDates: true,
+    })
+
+    let dayClasses = wrapper.vm.dayClasses(day)
+
+    expect(dayClasses.today).toBeTruthy()
+
+    await wrapper.setProps({
+      showEdgeDates: false,
+    })
+
+    dayClasses = wrapper.vm.dayClasses(day)
+
+    expect(dayClasses.today).toBeFalsy()
+  })
+
+  it('only highlights selected edge date if shown', async () => {
+    const day = {
+      date: 1,
+      isSelected: true,
+      isPreviousMonth: false,
+      isNextMonth: true,
+    }
+
+    await wrapper.setProps({
+      showEdgeDates: true,
+    })
+
+    let dayClasses = wrapper.vm.dayClasses(day)
+
+    expect(dayClasses.selected).toBeTruthy()
+
+    await wrapper.setProps({
+      showEdgeDates: false,
+    })
+
+    dayClasses = wrapper.vm.dayClasses(day)
+
+    expect(dayClasses.selected).toBeFalsy()
+  })
 })


### PR DESCRIPTION
Similar to the PR re. today's date (#101), we only want to highlight a selected edge date when `show-edge-dates` is true. 