### PR TITLE
Rollup: Set preventAssignment to true

### DIFF
--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -32,6 +32,7 @@ export default {
     }),
     replace({
       'process.env.NODE_ENV': JSON.stringify('development'),
+      'preventAssignment': true,
     }),
     resolve({
       module: true,


### PR DESCRIPTION
Avoids the following warning when running `npm run serve`;

    (!) Plugin replace: @rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.