### PR TITLE
Add a transition on toggle and view change

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -58,40 +58,44 @@
           :class="pickerClasses"
           @mousedown.prevent
         >
-          <slot name="beforeCalendarHeader" />
-          <Component
-            :is="picker"
-            class="picker-view"
-            :day-cell-content="dayCellContent"
-            :disabled-dates="disabledDates"
-            :first-day-of-week="firstDayOfWeek"
-            :highlighted="highlighted"
-            :is-rtl="isRtl"
-            :is-up-disabled="isUpDisabled"
-            :page-date="pageDate"
-            :selected-date="selectedDate"
-            :show-edge-dates="showEdgeDates"
-            :show-full-month-name="fullMonthName"
-            :show-header="showHeader"
-            :transition-name="transitionName"
-            :translation="translation"
-            :use-utc="useUtc"
-            :view="view || computedInitialView"
-            :year-range="yearPickerRange"
-            @page-change="handlePageChange"
-            @select="handleSelect"
-            @select-disabled="handleSelectDisabled"
-            @set-transition-name="setTransitionName($event)"
-            @set-view="setView"
-          >
-            <template v-for="slotKey of calendarSlots">
-              <slot :slot="slotKey" :name="slotKey" />
-            </template>
-            <template #dayCellContent="{ cell }">
-              <slot v-if="cell" name="dayCellContent" :cell="cell" />
-            </template>
-          </Component>
-          <slot name="calendarFooter" />
+          <Transition name="view">
+            <div :key="view">
+              <slot name="beforeCalendarHeader" />
+              <Component
+                :is="picker"
+                class="picker-view"
+                :day-cell-content="dayCellContent"
+                :disabled-dates="disabledDates"
+                :first-day-of-week="firstDayOfWeek"
+                :highlighted="highlighted"
+                :is-rtl="isRtl"
+                :is-up-disabled="isUpDisabled"
+                :page-date="pageDate"
+                :selected-date="selectedDate"
+                :show-edge-dates="showEdgeDates"
+                :show-full-month-name="fullMonthName"
+                :show-header="showHeader"
+                :transition-name="transitionName"
+                :translation="translation"
+                :use-utc="useUtc"
+                :view="view || computedInitialView"
+                :year-range="yearPickerRange"
+                @page-change="handlePageChange"
+                @select="handleSelect"
+                @select-disabled="handleSelectDisabled"
+                @set-transition-name="setTransitionName($event)"
+                @set-view="setView"
+              >
+                <template v-for="slotKey of calendarSlots">
+                  <slot :slot="slotKey" :name="slotKey" />
+                </template>
+                <template #dayCellContent="{ cell }">
+                  <slot v-if="cell" name="dayCellContent" :cell="cell" />
+                </template>
+              </Component>
+              <slot name="calendarFooter" />
+            </div>
+          </Transition>
         </div>
       </Transition>
     </Popup>

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -50,48 +50,50 @@
       :rtl="isRtl"
       :visible="isOpen"
     >
-      <div
-        v-show="isOpen"
-        ref="datepicker"
-        class="vdp-datepicker__calendar"
-        :class="pickerClasses"
-        @mousedown.prevent
-      >
-        <slot name="beforeCalendarHeader" />
-        <Component
-          :is="picker"
-          class="picker-view"
-          :day-cell-content="dayCellContent"
-          :disabled-dates="disabledDates"
-          :first-day-of-week="firstDayOfWeek"
-          :highlighted="highlighted"
-          :is-rtl="isRtl"
-          :is-up-disabled="isUpDisabled"
-          :page-date="pageDate"
-          :selected-date="selectedDate"
-          :show-edge-dates="showEdgeDates"
-          :show-full-month-name="fullMonthName"
-          :show-header="showHeader"
-          :transition-name="transitionName"
-          :translation="translation"
-          :use-utc="useUtc"
-          :view="view || computedInitialView"
-          :year-range="yearPickerRange"
-          @page-change="handlePageChange"
-          @select="handleSelect"
-          @select-disabled="handleSelectDisabled"
-          @set-transition-name="setTransitionName($event)"
-          @set-view="setView"
+      <Transition name="toggle">
+        <div
+          v-show="isOpen"
+          ref="datepicker"
+          class="vdp-datepicker__calendar"
+          :class="pickerClasses"
+          @mousedown.prevent
         >
-          <template v-for="slotKey of calendarSlots">
-            <slot :slot="slotKey" :name="slotKey" />
-          </template>
-          <template #dayCellContent="{ cell }">
-            <slot v-if="cell" name="dayCellContent" :cell="cell" />
-          </template>
-        </Component>
-        <slot name="calendarFooter" />
-      </div>
+          <slot name="beforeCalendarHeader" />
+          <Component
+            :is="picker"
+            class="picker-view"
+            :day-cell-content="dayCellContent"
+            :disabled-dates="disabledDates"
+            :first-day-of-week="firstDayOfWeek"
+            :highlighted="highlighted"
+            :is-rtl="isRtl"
+            :is-up-disabled="isUpDisabled"
+            :page-date="pageDate"
+            :selected-date="selectedDate"
+            :show-edge-dates="showEdgeDates"
+            :show-full-month-name="fullMonthName"
+            :show-header="showHeader"
+            :transition-name="transitionName"
+            :translation="translation"
+            :use-utc="useUtc"
+            :view="view || computedInitialView"
+            :year-range="yearPickerRange"
+            @page-change="handlePageChange"
+            @select="handleSelect"
+            @select-disabled="handleSelectDisabled"
+            @set-transition-name="setTransitionName($event)"
+            @set-view="setView"
+          >
+            <template v-for="slotKey of calendarSlots">
+              <slot :slot="slotKey" :name="slotKey" />
+            </template>
+            <template #dayCellContent="{ cell }">
+              <slot v-if="cell" name="dayCellContent" :cell="cell" />
+            </template>
+          </Component>
+          <slot name="calendarFooter" />
+        </div>
+      </Transition>
     </Popup>
   </div>
 </template>

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -14,10 +14,14 @@
 
 .vdp-datepicker__calendar {
   background: #fff;
-  border: 1px solid #ccc;
   position: absolute;
   width: 300px;
   z-index: 10000;
+
+  > div {
+    background: #fff;
+    border: 1px solid #ccc;
+  }
 
   .today {
     background-color: #eee;
@@ -237,6 +241,20 @@
 
 .toggle-enter,
 .toggle-leave-to {
+  opacity: 0;
+}
+
+.view-leave-active {
+  position: absolute;
+}
+
+.view-enter-active,
+.view-leave-active {
+  transition: all 250ms ease;
+}
+
+.view-enter,
+.view-leave-to {
   opacity: 0;
 }
 

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -230,6 +230,16 @@
   }
 }
 
+.toggle-enter-active,
+.toggle-leave-active {
+  transition: all 250ms ease;
+}
+
+.toggle-enter,
+.toggle-leave-to {
+  opacity: 0;
+}
+
 .vdp-datepicker__clear-button,
 .vdp-datepicker__calendar-button {
   cursor: pointer;


### PR DESCRIPTION
This adds a fade transition of 250 ms on opening or closing the calendar as well as when changing between views e.g. day -> month (or vice versa).