### PR TITLE
Fix calendar width

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -21,6 +21,7 @@
   > div {
     background: #fff;
     border: 1px solid #ccc;
+    width: inherit;
   }
 
   .today {


### PR DESCRIPTION
Fixes a bug (noticeable on the `inline` datepicker) where the calendar initially shows at full width before reverting to 300 px.