### PR TITLE
Fix day content slot regression

### DIFF
--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -38,7 +38,9 @@
             view="day"
             @select="select($event)"
           >
-            {{ dayCellContent(cell) }}
+            <slot name="dayCellContent" :cell="cell">
+              {{ dayCellContent(cell) }}
+            </slot>
           </PickerCells>
         </Transition>
       </div>

--- a/test/unit/specs/PickerDay/pickerDay.spec.js
+++ b/test/unit/specs/PickerDay/pickerDay.spec.js
@@ -155,3 +155,23 @@ describe('PickerDay', () => {
     expect(cellClasses[2].selected).toBeFalsy()
   })
 })
+
+describe('PickerDay with scoped slot', () => {
+  it('displays the dayCellContent scoped slot correctly', () => {
+    const wrapper = mount(PickerDay, {
+      propsData: {
+        translation: en,
+        pageDate: new Date(2018, 1, 1),
+      },
+      scopedSlots: {
+        dayCellContent: `<template #dayCellContent="{ cell }">
+                          <span>test{{ cell.date }}</span>
+                        </template>`,
+      },
+    })
+
+    const firstCell = wrapper.find('.cell')
+
+    expect(firstCell.text()).toBe('test28')
+  })
+})


### PR DESCRIPTION
Fixes a regression that occurred when the `PickerCells` were extracted to their own component. Resolves #117 