### PR TITLE
Remove unnecessary transition name

### DIFF
--- a/src/components/PickerCells.vue
+++ b/src/components/PickerCells.vue
@@ -23,10 +23,6 @@ export default {
       type: Boolean,
       default: true,
     },
-    transitionName: {
-      type: String,
-      default: '',
-    },
     view: {
       type: String,
       validator: (val) => ['day', 'month', 'year'].includes(val),


### PR DESCRIPTION
The `transitionName` prop is not needed in `PickerCells`.