### PR TITLE
Compute nextView up/down correctly

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -240,11 +240,6 @@ export default {
     }
   },
   computed: {
-    allowedViews() {
-      const views = ['day', 'month', 'year']
-
-      return views.filter((view) => this.allowedToShowView(view))
-    },
     computedInitialView() {
       return this.initialView || this.minimumView
     },
@@ -261,21 +256,22 @@ export default {
       return !this.allowedToShowView(this.nextView.up)
     },
     nextView() {
+      const views = ['day', 'month', 'year']
       const isCurrentView = (view) => view === this.view
-      const viewIndex = this.allowedViews.findIndex(isCurrentView)
+      const viewIndex = views.findIndex(isCurrentView)
       const nextViewDown = (index) => {
-        return index <= 0 ? undefined : this.allowedViews[index - 1]
+        return index <= 0 ? undefined : views[index - 1]
       }
       const nextViewUp = (index) => {
         if (index < 0) {
           return undefined
         }
 
-        if (index === this.allowedViews.length - 1) {
+        if (index === views.length - 1) {
           return 'decade'
         }
 
-        return this.allowedViews[index + 1]
+        return views[index + 1]
       }
 
       return {

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -318,6 +318,23 @@ describe('Datepicker shallowMounted', () => {
     expect(datepicker.element.className).toContain('rtl')
   })
 
+  it('knows the next view up / down', async () => {
+    wrapper.vm.setView('day')
+
+    expect(wrapper.vm.nextView.down).toBeUndefined()
+    expect(wrapper.vm.nextView.up).toBe('month')
+
+    wrapper.vm.setView('month')
+
+    expect(wrapper.vm.nextView.down).toBe('day')
+    expect(wrapper.vm.nextView.up).toBe('year')
+
+    wrapper.vm.setView('year')
+
+    expect(wrapper.vm.nextView.down).toBe('month')
+    expect(wrapper.vm.nextView.up).toBe('decade')
+  })
+
   it('should emit changed-month/year/decade', async () => {
     const pageDate = new Date(2016, 2, 1)
     await wrapper.vm.setView('day')


### PR DESCRIPTION
Fixes #121 and adds a test to ensure `nextView.up` / `nextView.down` is calculated correctly.