### PR TITLE
feat(datepicker): add preservTime property

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -214,6 +214,10 @@ export default {
       type: Number,
       default: 10,
     },
+    preserveTime: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     const utils = makeDateUtils(this.useUtc)
@@ -448,6 +452,12 @@ export default {
      */
     selectDate(timestamp) {
       const date = new Date(timestamp)
+
+      if (this.preserveTime) {
+        date.setHours(this.selectedDate.getHours())
+        date.setMinutes(this.selectedDate.getMinutes())
+        date.setSeconds(this.selectedDate.getSeconds())
+      }
       this.selectedDate = date
       this.setPageDate(date)
       this.$emit('selected', date)

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -184,6 +184,30 @@ describe('Datepicker shallowMounted', () => {
     expect(wrapper.emitted('selected')).toBeTruthy()
   })
 
+  it('can select a day preserving time', () => {
+    const selected = new Date(2021, 7, 1, 15, 12, 36)
+
+    wrapper.setProps({
+      preserveTime: true,
+    })
+
+    wrapper.vm.setValue(selected)
+
+    const dateTemp = new Date(2016, 9, 1)
+    wrapper.vm.handleSelect({ timestamp: dateTemp.valueOf() })
+
+    const [selectedEvents] = wrapper.emitted('selected')
+    const output = selectedEvents[0]
+
+    expect(output.getHours()).toEqual(selected.getHours())
+    expect(output.getMinutes()).toEqual(selected.getMinutes())
+    expect(output.getSeconds()).toEqual(selected.getSeconds())
+
+    expect(output.getDate()).toEqual(dateTemp.getDate())
+    expect(output.getMonth()).toEqual(dateTemp.getMonth())
+    expect(output.getFullYear()).toEqual(dateTemp.getFullYear())
+  })
+
   it('can select a month', () => {
     const dateTemp = new Date(2016, 9, 9)
     wrapper.vm.setView('month')


### PR DESCRIPTION
With this property, component will emit new date object but it will use time component that was set as an input.