### PR TITLE
fix(datepicker): Remove hours/minutes/(milli)seconds from pageDate

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -650,8 +650,9 @@ export default {
         } else {
           dateTemp = new Date()
         }
-        dateTemp = this.utils.resetDateTime(dateTemp)
       }
+      dateTemp = this.utils.resetDateTime(new Date(dateTemp))
+
       this.pageTimestamp = this.utils.setDate(new Date(dateTemp), 1)
     },
     /**


### PR DESCRIPTION
I believe this should fix issue #143.