### PR TITLE
Typeable calendar: Don't automatically select the date when a typed date changes

### DIFF
--- a/docs/.vuepress/components/Formats.vue
+++ b/docs/.vuepress/components/Formats.vue
@@ -23,31 +23,31 @@ export default {
       format: '',
       formats: [
         {
-          text: 'MMMM d, yyyy &nbsp;&nbsp;&nbsp; e.g. February 6, 2022',
+          text: 'MMMM d, yyyy e.g. February 6, 2022',
           value: 'MMMM d, yyyy',
         },
         {
-          text: 'do MMM yyyy &nbsp;&nbsp;&nbsp; e.g. 6th Feb 2022',
+          text: 'do MMM yyyy e.g. 6th Feb 2022',
           value: 'do MMM yyyy',
         },
         {
-          text: 'yyyy-MM-dd &nbsp;&nbsp;&nbsp; e.g. 2022-02-06',
+          text: 'yyyy-MM-dd e.g. 2022-02-06',
           value: 'yyyy-MM-dd',
         },
         {
-          text: 'E do MMM yyyy &nbsp;&nbsp;&nbsp; e.g. Sun 6th Feb 2022',
+          text: 'E do MMM yyyy e.g. Sun 6th Feb 2022',
           value: 'E do MMM yyyy',
         },
         {
-          text: 'dd/MM/yy &nbsp;&nbsp;&nbsp; e.g. 06/02/22',
+          text: 'dd/MM/yy e.g. 06/02/22',
           value: 'dd/MM/yy',
         },
         {
-          text: 'dd.MM.yyyy &nbsp;&nbsp;&nbsp; e.g. 06.02.2022',
+          text: 'dd.MM.yyyy e.g. 06.02.2022',
           value: 'dd.MM.yyyy',
         },
         {
-          text: 'M/d/yyyy &nbsp;&nbsp;&nbsp; e.g. 2/6/2022',
+          text: 'M/d/yyyy e.g. 2/6/2022',
           value: 'M/d/yyyy',
         },
       ],

--- a/docs/.vuepress/components/Formats.vue
+++ b/docs/.vuepress/components/Formats.vue
@@ -23,28 +23,32 @@ export default {
       format: '',
       formats: [
         {
-          text: 'd MMMM yyyy - e.g 12 February 2016',
-          value: 'd MMMM yyyy',
+          text: 'MMMM d, yyyy &nbsp;&nbsp;&nbsp; e.g. February 6, 2022',
+          value: 'MMMM d, yyyy',
         },
         {
-          text: 'yyyy-MM-dd - e.g 2016-02-12',
-          value: 'yyyy-MM-dd',
-        },
-        {
-          text: 'do MMM yyyy - e.g 12th Feb 2016',
+          text: 'do MMM yyyy &nbsp;&nbsp;&nbsp; e.g. 6th Feb 2022',
           value: 'do MMM yyyy',
         },
         {
-          text: 'E do MMM yyyy - e.g Sat 12th Feb 2016',
+          text: 'yyyy-MM-dd &nbsp;&nbsp;&nbsp; e.g. 2022-02-06',
+          value: 'yyyy-MM-dd',
+        },
+        {
+          text: 'E do MMM yyyy &nbsp;&nbsp;&nbsp; e.g. Sun 6th Feb 2022',
           value: 'E do MMM yyyy',
         },
         {
-          text: 'dd.MM.yyyy - 20.12.2019',
+          text: 'dd/MM/yy &nbsp;&nbsp;&nbsp; e.g. 06/02/22',
+          value: 'dd/MM/yy',
+        },
+        {
+          text: 'dd.MM.yyyy &nbsp;&nbsp;&nbsp; e.g. 06.02.2022',
           value: 'dd.MM.yyyy',
         },
         {
-          text: 'MM.dd.yyyy - 08.30.2019',
-          value: 'MM.dd.yyyy',
+          text: 'M/d/yyyy &nbsp;&nbsp;&nbsp; e.g. 2/6/2022',
+          value: 'M/d/yyyy',
         },
       ],
     }

--- a/docs/.vuepress/sidebar.js
+++ b/docs/.vuepress/sidebar.js
@@ -6,6 +6,7 @@ module.exports = [
       ['/guide/', 'Getting started'],
       '/guide/Migration/',
       '/guide/DateFormatting/',
+      '/guide/ParsingDates/',
       '/guide/DisabledDates/',
       '/guide/Events/',
       '/guide/HighlightedDates/',

--- a/docs/guide/DateFormatting/README.md
+++ b/docs/guide/DateFormatting/README.md
@@ -2,7 +2,8 @@
 
 ## String formatter
 
-NB. This is not very robust at all - use at your own risk! Needs a better implementation.
+The default format is 'dd MMM yyyy' e.g. 05 Jan 2022. However, you can use the following tokens to build up your own
+`format` string:
 
 | Token | Desc                   | Example     |
 |-------|------------------------|-------------|
@@ -17,22 +18,29 @@ NB. This is not very robust at all - use at your own risk! Needs a better implem
 | yy    | two digit year         | 16          |
 | yyyy  | four digit year        | 2016        |
 
+For example, the following string would format the date as 'January 5th, 2022':
+
+```vue
+<template>
+  <DatePicker format="MMMM do, yyyy"></DatePicker>
+</template>
+```
+
 ## Function formatter
 
 Delegates date formatting to a function provided by the `format` prop.
 The function will be called with the date - and it has to return the formatted date as a string.
 This allows us to use moment, date-fns, globalize or any other library to format the date.
-The formatter function needs a custom `parser` to parse the formatted date back to a date object.
 
-Here is an example for date-fns:
+Here is an example using [date-fns](https://date-fns.org/):
 
 ```vue
 <template>
-  <DatePicker :format="customFormatter" :parser="customParser"></DatePicker>
+  <DatePicker :format="customFormatter"></DatePicker>
 </template>
 
 <script>
-import { format, parse } from 'date-fns'
+import { format } from 'date-fns'
 
 export default {
   data() {
@@ -43,9 +51,6 @@ export default {
   methods: {
     customFormatter(date) {
       return format(date, this.format)
-    },
-    customParser(date) {
-      return parse(date, this.format, new Date())
     },
   },
 }

--- a/docs/guide/DateFormatting/README.md
+++ b/docs/guide/DateFormatting/README.md
@@ -5,7 +5,7 @@
 NB. This is not very robust at all - use at your own risk! Needs a better implementation.
 
 | Token | Desc                   | Example     |
-| ----- | ---------------------- | ----------- |
+|-------|------------------------|-------------|
 | d     | day                    | 1           |
 | dd    | 0 prefixed day         | 01          |
 | E     | abbr day               | Mon         |
@@ -19,12 +19,10 @@ NB. This is not very robust at all - use at your own risk! Needs a better implem
 
 ## Function formatter
 
-Delegates date formatting to provided function.
-Function will be called with date and it has to return the formatted date as a string.
-This allow us to use moment, date-fns, globalize or any other library to format date.
-Be aware of the fact that if you use a typeable datepicker the formatting function will be
-triggered on every input change.
-The function formatter needs a custom parser to parse the formatted date back to date object.
+Delegates date formatting to a function provided by the `format` prop.
+The function will be called with the date - and it has to return the formatted date as a string.
+This allows us to use moment, date-fns, globalize or any other library to format the date.
+The formatter function needs a custom `parser` to parse the formatted date back to a date object.
 
 Here is an example for date-fns:
 
@@ -32,8 +30,10 @@ Here is an example for date-fns:
 <template>
   <DatePicker :format="customFormatter" :parser="customParser"></DatePicker>
 </template>
+
 <script>
 import { format, parse } from 'date-fns'
+
 export default {
   data() {
     return {

--- a/docs/guide/ParsingDates/README.md
+++ b/docs/guide/ParsingDates/README.md
@@ -1,0 +1,54 @@
+# Parsing typed input
+
+## Default parsing
+When you type into a `typeable` datepicker, each time you 'key-up', the datepicker
+will try to parse your input to a valid date. When the input field loses focus, the
+date is either formatted, or cleared if no valid is found.
+
+*N.B. Since version 5.0, the datepicker no longer submits the date each time a valid date
+is typed; a typed date is only submitted a) on pressing the enter key, or b) when
+the datepicker loses focus entirely.*
+
+
+```vue
+<template>
+  <DatePicker :typeable="true"></DatePicker>
+</template>
+```
+The parser doesn't always get it right! For example, it doesn't like date
+suffixes such as 1st, 2nd or 3rd. And dates such as 02/07/2022 are currently
+interpreted as 07 Feb 2022, not 02 Jul 2022 - which may, or may not, be what
+you were expecting? If you'd like to help improve the parser, please feel free
+to submit a PR!
+
+## Parser function
+
+If you know the format in which you expect a date to be typed, you can provide a
+function for parsing the date via the `parser` prop. This function will then be
+called instead of the default parser. We can use moment, date-fns, globalize or
+any other library to parse the input, so long as it returns a date from string.
+
+Here is an example using [date-fns](https://date-fns.org/):
+
+```vue
+<template>
+  <DatePicker :parser="customParser"></DatePicker>
+</template>
+
+<script>
+import { parse } from 'date-fns'
+
+export default {
+  data() {
+    return {
+      format: 'dd.MM.yyyy',
+    }
+  },
+  methods: {
+    customParser(date) {
+      return parse(date, this.format, new Date())
+    },
+  },
+}
+</script>
+```

--- a/docs/guide/ParsingDates/README.md
+++ b/docs/guide/ParsingDates/README.md
@@ -5,9 +5,10 @@ When you type into a `typeable` datepicker, each time you 'key-up', the datepick
 will try to parse your input to a valid date. When the input field loses focus, the
 date is either formatted, or cleared if no valid is found.
 
-*N.B. Since version 5.0, the datepicker no longer submits the date each time a valid date
-is typed; a typed date is only submitted a) on pressing the enter key, or b) when
-the datepicker loses focus entirely.*
+*N.B. Since version 5.0, the datepicker no longer submits the date each time a valid
+date is typed. A typed date is only submitted - and a `selected` event fired - a) on pressing
+the enter key, or b) when the datepicker loses focus entirely. `input` events, however,
+continue to be fired each time a change in the input field occurs and a valid date is detected.*
 
 
 ```vue

--- a/docs/guide/ParsingDates/README.md
+++ b/docs/guide/ParsingDates/README.md
@@ -19,7 +19,7 @@ continue to be fired each time a change in the input field occurs and a valid da
 The parser doesn't always get it right! For example, it doesn't like date
 suffixes such as 1st, 2nd or 3rd. And dates such as 02/07/2022 are currently
 interpreted as 07 Feb 2022, not 02 Jul 2022 - which may, or may not, be what
-you were expecting? If you'd like to help improve the parser, please feel free
+you were expecting. If you'd like to help improve the parser, please feel free
 to submit a PR!
 
 ## Parser function
@@ -29,15 +29,19 @@ function for parsing the date via the `parser` prop. This function will then be
 called instead of the default parser. We can use moment, date-fns, globalize or
 any other library to parse the input, so long as it returns a date from string.
 
+Be aware of the fact that if you use a custom parsing function, you will also
+need to pass in a custom `format` function in order for the formatted date to be
+correctly parsed back to a date object.
+
 Here is an example using [date-fns](https://date-fns.org/):
 
 ```vue
 <template>
-  <DatePicker :parser="customParser"></DatePicker>
+  <DatePicker :format="customFormatter" :parser="customParser"></DatePicker>
 </template>
 
 <script>
-import { parse } from 'date-fns'
+import { format, parse } from 'date-fns'
 
 export default {
   data() {
@@ -46,6 +50,9 @@ export default {
     }
   },
   methods: {
+    customFormatter(date) {
+      return format(date, this.format)
+    },
     customParser(date) {
       return parse(date, this.format, new Date())
     },

--- a/example/Demo.vue
+++ b/example/Demo.vue
@@ -92,6 +92,34 @@
     </div>
 
     <div class="example">
+      <h3>Format a date with the date-fns library</h3>
+      <Datepicker
+        :format="customFormatter"
+        v-model="state"
+      />
+      <code>
+        &lt;datepicker :format="customFormatter"&gt;&lt;/datepicker&gt;
+      </code>
+      <div class="settings">
+        <h5>Settings</h5>
+        <div class="form-group">
+          <label>Format</label>
+          <select v-model="formatDateFns">
+            <option value="qqq yyyy">qqq yyyy &nbsp;&nbsp;&nbsp;e.g. Q1 2022</option>
+            <option value="EEEE do MMMM yyyy">EEEE do MMMM yyyy &nbsp;&nbsp;&nbsp;e.g. Sunday 6th February 2022</option>
+            <option value="MMMM d, yyyy">MMMM d, yyyy &nbsp;&nbsp;&nbsp;e.g. February 6, 2022</option>
+            <option value="do MMM yyyy">do MMM yyyy &nbsp;&nbsp;&nbsp;e.g. 6th Feb 2022</option>
+            <option value="yyyy-MM-dd">yyyy-MM-dd &nbsp;&nbsp;&nbsp;e.g. 2022-02-06</option>
+            <option value="E do MMM yyyy">E do MMM yyyy &nbsp;&nbsp;&nbsp;e.g. Sun 6th Feb 2022</option>
+            <option value="dd/MM/yy">dd/MM/yy &nbsp;&nbsp;&nbsp;e.g. 06/02/22</option>
+            <option value="dd.MM.yyyy">dd.MM.yyyy &nbsp;&nbsp;&nbsp;e.g. 06.02.2022</option>
+            <option value="M/d/yyyy">M/d/yyyy &nbsp;&nbsp;&nbsp;e.g. 2/6/2022</option>
+          </select>
+        </div>
+      </div>
+    </div>
+
+    <div class="example">
       <h3>With minimum and maximum date range</h3>
       <Datepicker :disabled-dates="disabledDates" />
       <code>
@@ -332,6 +360,7 @@
 
 <script>
 import Datepicker from '~/components/Datepicker.vue'
+import { format, parse } from 'date-fns'
 import * as lang from '~/locale/index'
 
 export default {
@@ -393,6 +422,7 @@ export default {
         'top-right',
       ],
       format: 'MMMM d, yyyy',
+      formatDateFns: 'MMMM d, yyyy',
       highlighted: {},
       highlightedFn: {
         customPredictor(date) {
@@ -417,6 +447,12 @@ export default {
     },
   },
   methods: {
+    customFormatter(date) {
+      return format(date, this.formatDateFns)
+    },
+    customParser(date) {
+      return parse(date, this.formatDateFns, new Date())
+    },
     disableTo(val) {
       if (typeof this.disabledDates.to === 'undefined') {
         this.disabledDates = {

--- a/example/Demo.vue
+++ b/example/Demo.vue
@@ -11,10 +11,10 @@
 
     <div class="example">
       <h3>Custom first-day-of-week datepicker</h3>
-      <Datepicker placeholder="Type or select date" first-day-of-week="mon" />
+      <Datepicker placeholder="Select date" first-day-of-week="mon" />
       <code>
-        &lt;datepicker placeholder="Type or select date" first-day-of-week="mon"
-        &gt;&lt;/datepicker&gt;
+        &lt;datepicker placeholder="Select date"
+        first-day-of-week="mon"&gt;&lt;/datepicker&gt;
       </code>
     </div>
 
@@ -29,9 +29,9 @@
 
     <div class="example">
       <h3>Only show dates from current month datepicker</h3>
-      <Datepicker placeholder="Type or select date" :show-edge-dates="false" />
+      <Datepicker placeholder="Select date" :show-edge-dates="false" />
       <code>
-        &lt;datepicker placeholder="Type or select date"
+        &lt;datepicker placeholder="Select date"
         :show-edge-dates="false"&gt;&lt;/datepicker&gt;
       </code>
     </div>
@@ -53,7 +53,6 @@
       <Datepicker
         v-model="vModelExample"
         placeholder="Select Date"
-        :append-to-body="true"
       />
       <code>
         &lt;datepicker placeholder="Select Date"
@@ -339,10 +338,6 @@
 import Datepicker from '~/components/Datepicker.vue'
 import * as lang from '~/locale/index'
 
-const state = {
-  date1: new Date(),
-}
-
 export default {
   name: 'Demo',
   components: {
@@ -350,10 +345,7 @@ export default {
   },
   data() {
     return {
-      styleInput: null,
-      format: 'd MMMM yyyy',
       disabledDates: {},
-      openDate: null,
       disabledFn: {
         customPredictor(date) {
           const year = date.getFullYear()
@@ -394,21 +386,8 @@ export default {
           return false
         }
       }`,
-      highlightedFn: {
-        customPredictor(date) {
-          if (date.getDate() % 4 === 0) {
-            return true
-          }
-          return false
-        },
-      },
-      highlighted: {},
       eventMsg: null,
-      state,
-      vModelExample: null,
-      languages: lang,
-      language: 'en',
-      yearPickerRange: 10,
+      fixedPosition: 'bottom',
       fixedPositions: [
         'bottom',
         'bottom-left',
@@ -417,7 +396,23 @@ export default {
         'top-left',
         'top-right',
       ],
-      fixedPosition: 'bottom',
+      format: 'MMMM d, yyyy',
+      highlighted: {},
+      highlightedFn: {
+        customPredictor(date) {
+          if (date.getDate() % 4 === 0) {
+            return true
+          }
+          return false
+        },
+      },
+      language: 'en',
+      languages: lang,
+      openDate: null,
+      state: new Date(),
+      styleInput: null,
+      vModelExample: null,
+      yearPickerRange: 10,
     }
   },
   computed: {
@@ -426,6 +421,26 @@ export default {
     },
   },
   methods: {
+    disableTo(val) {
+      if (typeof this.disabledDates.to === 'undefined') {
+        this.disabledDates = {
+          to: null,
+          daysOfMonth: this.disabledDates.daysOfMonth,
+          from: this.disabledDates.from,
+        }
+      }
+      this.disabledDates.to = val
+    },
+    disableFrom(val) {
+      if (typeof this.disabledDates.from === 'undefined') {
+        this.disabledDates = {
+          to: this.disabledDates.to,
+          daysOfMonth: this.disabledDates.daysOfMonth,
+          from: null,
+        }
+      }
+      this.disabledDates.from = val
+    },
     highlightTo(val) {
       if (typeof this.highlighted.to === 'undefined') {
         this.highlighted = {
@@ -446,19 +461,6 @@ export default {
       }
       this.highlighted.from = val
     },
-    setHighlightedDays(elem) {
-      if (elem.target.value === 'undefined') {
-        return
-      }
-      const highlightedDays = elem.target.value
-        .split(',')
-        .map((day) => parseInt(day, 10))
-      this.highlighted = {
-        from: this.highlighted.from,
-        to: this.highlighted.to,
-        daysOfMonth: highlightedDays,
-      }
-    },
     setDisabledDays(elem) {
       if (elem.target.value === 'undefined') {
         return
@@ -472,25 +474,18 @@ export default {
         daysOfMonth: disabledDays,
       }
     },
-    disableTo(val) {
-      if (typeof this.disabledDates.to === 'undefined') {
-        this.disabledDates = {
-          to: null,
-          daysOfMonth: this.disabledDates.daysOfMonth,
-          from: this.disabledDates.from,
-        }
+    setHighlightedDays(elem) {
+      if (elem.target.value === 'undefined') {
+        return
       }
-      this.disabledDates.to = val
-    },
-    disableFrom(val) {
-      if (typeof this.disabledDates.from === 'undefined') {
-        this.disabledDates = {
-          to: this.disabledDates.to,
-          daysOfMonth: this.disabledDates.daysOfMonth,
-          from: null,
-        }
+      const highlightedDays = elem.target.value
+        .split(',')
+        .map((day) => parseInt(day, 10))
+      this.highlighted = {
+        from: this.highlighted.from,
+        to: this.highlighted.to,
+        daysOfMonth: highlightedDays,
       }
-      this.disabledDates.from = val
     },
   },
 }

--- a/example/Demo.vue
+++ b/example/Demo.vue
@@ -72,7 +72,7 @@
 
     <div class="example">
       <h3>Format datepicker</h3>
-      <Datepicker :format="format" v-model="state"/>
+      <Datepicker :format="format"/>
       <code>&lt;datepicker format="format"&gt;&lt;/datepicker&gt;</code>
       <div class="settings">
         <h5>Settings</h5>

--- a/example/Demo.vue
+++ b/example/Demo.vue
@@ -79,13 +79,13 @@
         <div class="form-group">
           <label>Format</label>
           <select v-model="format">
-            <option value="MMMM d, yyyy">MMMM d, yyyy &nbsp;&nbsp;&nbsp;e.g. February 6, 2022</option>
-            <option value="do MMM yyyy">do MMM yyyy &nbsp;&nbsp;&nbsp;e.g. 6th Feb 2022</option>
-            <option value="yyyy-MM-dd">yyyy-MM-dd &nbsp;&nbsp;&nbsp;e.g. 2022-02-06</option>
-            <option value="E do MMM yyyy">E do MMM yyyy &nbsp;&nbsp;&nbsp;e.g. Sun 6th Feb 2022</option>
-            <option value="dd/MM/yy">dd/MM/yy &nbsp;&nbsp;&nbsp;e.g. 06/02/22</option>
-            <option value="dd.MM.yyyy">dd.MM.yyyy &nbsp;&nbsp;&nbsp;e.g. 06.02.2022</option>
-            <option value="M/d/yyyy">M/d/yyyy &nbsp;&nbsp;&nbsp;e.g. 2/6/2022</option>
+            <option value="MMMM d, yyyy">MMMM d, yyyy e.g. February 6, 2022</option>
+            <option value="do MMM yyyy">do MMM yyyy e.g. 6th Feb 2022</option>
+            <option value="yyyy-MM-dd">yyyy-MM-dd e.g. 2022-02-06</option>
+            <option value="E do MMM yyyy">E do MMM yyyy e.g. Sun 6th Feb 2022</option>
+            <option value="dd/MM/yy">dd/MM/yy e.g. 06/02/22</option>
+            <option value="dd.MM.yyyy">dd.MM.yyyy e.g. 06.02.2022</option>
+            <option value="M/d/yyyy">M/d/yyyy e.g. 2/6/2022</option>
           </select>
         </div>
       </div>
@@ -105,15 +105,15 @@
         <div class="form-group">
           <label>Format</label>
           <select v-model="formatDateFns">
-            <option value="qqq yyyy">qqq yyyy &nbsp;&nbsp;&nbsp;e.g. Q1 2022</option>
-            <option value="EEEE do MMMM yyyy">EEEE do MMMM yyyy &nbsp;&nbsp;&nbsp;e.g. Sunday 6th February 2022</option>
-            <option value="MMMM d, yyyy">MMMM d, yyyy &nbsp;&nbsp;&nbsp;e.g. February 6, 2022</option>
-            <option value="do MMM yyyy">do MMM yyyy &nbsp;&nbsp;&nbsp;e.g. 6th Feb 2022</option>
-            <option value="yyyy-MM-dd">yyyy-MM-dd &nbsp;&nbsp;&nbsp;e.g. 2022-02-06</option>
-            <option value="E do MMM yyyy">E do MMM yyyy &nbsp;&nbsp;&nbsp;e.g. Sun 6th Feb 2022</option>
-            <option value="dd/MM/yy">dd/MM/yy &nbsp;&nbsp;&nbsp;e.g. 06/02/22</option>
-            <option value="dd.MM.yyyy">dd.MM.yyyy &nbsp;&nbsp;&nbsp;e.g. 06.02.2022</option>
-            <option value="M/d/yyyy">M/d/yyyy &nbsp;&nbsp;&nbsp;e.g. 2/6/2022</option>
+            <option value="qqq yyyy">qqq yyyy e.g. Q1 2022</option>
+            <option value="EEEE do MMMM yyyy">EEEE do MMMM yyyy e.g. Sunday 6th February 2022</option>
+            <option value="MMMM d, yyyy">MMMM d, yyyy e.g. February 6, 2022</option>
+            <option value="do MMM yyyy">do MMM yyyy e.g. 6th Feb 2022</option>
+            <option value="yyyy-MM-dd">yyyy-MM-dd e.g. 2022-02-06</option>
+            <option value="E do MMM yyyy">E do MMM yyyy e.g. Sun 6th Feb 2022</option>
+            <option value="dd/MM/yy">dd/MM/yy e.g. 06/02/22</option>
+            <option value="dd.MM.yyyy">dd.MM.yyyy e.g. 06.02.2022</option>
+            <option value="M/d/yyyy">M/d/yyyy e.g. 2/6/2022</option>
           </select>
         </div>
       </div>

--- a/example/Demo.vue
+++ b/example/Demo.vue
@@ -72,24 +72,20 @@
 
     <div class="example">
       <h3>Format datepicker</h3>
-      <Datepicker :format="format" />
-      <code>&lt;datepicker :format="format"&gt;&lt;/datepicker&gt;</code>
+      <Datepicker :format="format" v-model="state"/>
+      <code>&lt;datepicker format="format"&gt;&lt;/datepicker&gt;</code>
       <div class="settings">
         <h5>Settings</h5>
         <div class="form-group">
           <label>Format</label>
           <select v-model="format">
-            <option value="d MMM yyyy" selected>
-              d MMM yyyy - e.g 12 Feb 2016
-            </option>
-            <option value="d MMMM yyyy">
-              d MMMM yyyy - e.g 12 February 2016
-            </option>
-            <option value="yyyy-MM-dd">yyyy-MM-dd - e.g 2016-02-12</option>
-            <option value="do MMM yyyy">do MMM yyyy - e.g 12th Feb 2016</option>
-            <option value="E do MMM yyyy">
-              E do MMM yyyy - e.g Sat 12th Feb 2016
-            </option>
+            <option value="MMMM d, yyyy">MMMM d, yyyy &nbsp;&nbsp;&nbsp;e.g. February 6, 2022</option>
+            <option value="do MMM yyyy">do MMM yyyy &nbsp;&nbsp;&nbsp;e.g. 6th Feb 2022</option>
+            <option value="yyyy-MM-dd">yyyy-MM-dd &nbsp;&nbsp;&nbsp;e.g. 2022-02-06</option>
+            <option value="E do MMM yyyy">E do MMM yyyy &nbsp;&nbsp;&nbsp;e.g. Sun 6th Feb 2022</option>
+            <option value="dd/MM/yy">dd/MM/yy &nbsp;&nbsp;&nbsp;e.g. 06/02/22</option>
+            <option value="dd.MM.yyyy">dd.MM.yyyy &nbsp;&nbsp;&nbsp;e.g. 06.02.2022</option>
+            <option value="M/d/yyyy">M/d/yyyy &nbsp;&nbsp;&nbsp;e.g. 2/6/2022</option>
           </select>
         </div>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@ampproject/remapping": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -967,16 +976,28 @@
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.16.7.tgz",
-      "integrity": "sha512-8D16ye66fxiE8m890w0BpPpngG9o9OVBBy0gH2E+2AR7qMR2ZpTYJEqLxAsoroenMId0p/wMW+Blc0meDgu0Ag==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.3.tgz",
+      "integrity": "sha512-9tjBm4O07f7mzKSIlEmPdiE6ub7kfIe6Cd+w+oQebpATfTQMAgW+YOuWxogbKVTulA+MEO7byMeIUtQ1z+z+ZQ==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.7",
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-jsx": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.17.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.17.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/plugin-transform-react-jsx-development": {
@@ -1296,6 +1317,13 @@
         "minimist": "^1.2.0"
       }
     },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "optional": true
+    },
     "@cypress/browserify-preprocessor": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@cypress/browserify-preprocessor/-/browserify-preprocessor-3.0.2.tgz",
@@ -1322,27 +1350,71 @@
         "watchify": "^4.0.0"
       },
       "dependencies": {
+        "@babel/compat-data": {
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
+          "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==",
+          "dev": true
+        },
         "@babel/core": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.7.tgz",
-          "integrity": "sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.9.tgz",
+          "integrity": "sha512-5ug+SfZCpDAkVp9SFIZAzlW18rlzsOcJGaetCjkySnrXXDUw9AR8cDUm1iByTmdWM6yxX6/zycaV76w3YTF2gw==",
           "dev": true,
           "requires": {
+            "@ampproject/remapping": "^2.1.0",
             "@babel/code-frame": "^7.16.7",
-            "@babel/generator": "^7.16.7",
-            "@babel/helper-compilation-targets": "^7.16.7",
-            "@babel/helper-module-transforms": "^7.16.7",
-            "@babel/helpers": "^7.16.7",
-            "@babel/parser": "^7.16.7",
+            "@babel/generator": "^7.17.9",
+            "@babel/helper-compilation-targets": "^7.17.7",
+            "@babel/helper-module-transforms": "^7.17.7",
+            "@babel/helpers": "^7.17.9",
+            "@babel/parser": "^7.17.9",
             "@babel/template": "^7.16.7",
-            "@babel/traverse": "^7.16.7",
-            "@babel/types": "^7.16.7",
+            "@babel/traverse": "^7.17.9",
+            "@babel/types": "^7.17.0",
             "convert-source-map": "^1.7.0",
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.2",
-            "json5": "^2.1.2",
-            "semver": "^6.3.0",
+            "json5": "^2.2.1",
+            "semver": "^6.3.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.9.tgz",
+          "integrity": "sha512-rAdDousTwxbIxbz5I7GEQ3lUip+xVCXooZNbsydCWs3xA7ZsYOv+CFRdzGxRX78BmQHu9B1Eso59AOZQOJDEdQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.17.0",
+            "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-compilation-targets": {
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
+          "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
+          "dev": true,
+          "requires": {
+            "@babel/compat-data": "^7.17.7",
+            "@babel/helper-validator-option": "^7.16.7",
+            "browserslist": "^4.17.5",
+            "semver": "^6.3.0"
+          }
+        },
+        "@babel/helper-create-class-features-plugin": {
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.9.tgz",
+          "integrity": "sha512-kUjip3gruz6AJKOq5i3nC6CoCEEF/oHH3cp6tOZhB+IyyyPyW0g1Gfsxn3mkk6S08pIA2y8GQh609v9G/5sHVQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.16.7",
+            "@babel/helper-environment-visitor": "^7.16.7",
+            "@babel/helper-function-name": "^7.17.9",
+            "@babel/helper-member-expression-to-functions": "^7.17.7",
+            "@babel/helper-optimise-call-expression": "^7.16.7",
+            "@babel/helper-replace-supers": "^7.16.7",
+            "@babel/helper-split-export-declaration": "^7.16.7"
           }
         },
         "@babel/helper-define-polyfill-provider": {
@@ -1361,10 +1433,81 @@
             "semver": "^6.1.2"
           }
         },
+        "@babel/helper-function-name": {
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
+          "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.16.7",
+            "@babel/types": "^7.17.0"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.17.7.tgz",
+          "integrity": "sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.17.0"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
+          "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-environment-visitor": "^7.16.7",
+            "@babel/helper-module-imports": "^7.16.7",
+            "@babel/helper-simple-access": "^7.17.7",
+            "@babel/helper-split-export-declaration": "^7.16.7",
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "@babel/template": "^7.16.7",
+            "@babel/traverse": "^7.17.3",
+            "@babel/types": "^7.17.0"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
+          "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.17.0"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
+          "integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.16.7",
+            "@babel/traverse": "^7.17.9",
+            "@babel/types": "^7.17.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.9.tgz",
+          "integrity": "sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==",
+          "dev": true
+        },
+        "@babel/plugin-proposal-private-methods": {
+          "version": "7.16.11",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.11.tgz",
+          "integrity": "sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-create-class-features-plugin": "^7.16.10",
+            "@babel/helper-plugin-utils": "^7.16.7"
+          }
+        },
         "@babel/plugin-transform-runtime": {
-          "version": "7.16.8",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.8.tgz",
-          "integrity": "sha512-6Kg2XHPFnIarNweZxmzbgYnnWsXxkx9WQUVk2sksBRL80lBC1RAQV3wQagWxdCHiYHqPN+oenwNIuttlYgIbQQ==",
+          "version": "7.17.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.17.0.tgz",
+          "integrity": "sha512-fr7zPWnKXNc1xoHfrIU9mN/4XKX4VLZ45Q+oMhfsYIaHvg7mHgmhfOy/ckRWqDK7XF3QDigRpkh5DKq6+clE8A==",
           "dev": true,
           "requires": {
             "@babel/helper-module-imports": "^7.16.7",
@@ -1376,9 +1519,9 @@
           }
         },
         "@babel/preset-env": {
-          "version": "7.16.8",
-          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.8.tgz",
-          "integrity": "sha512-9rNKgVCdwHb3z1IlbMyft6yIXIeP3xz6vWvGaLHrJThuEIqWfHb0DNBH9VuTgnDfdbUDhkmkvMZS/YMCtP7Elg==",
+          "version": "7.16.11",
+          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.11.tgz",
+          "integrity": "sha512-qcmWG8R7ZW6WBRPZK//y+E3Cli151B20W1Rv7ln27vuPaXU/8TKms6jFdiJtF7UDTxcrb7mZd88tAeK9LjdT8g==",
           "dev": true,
           "requires": {
             "@babel/compat-data": "^7.16.8",
@@ -1399,7 +1542,7 @@
             "@babel/plugin-proposal-object-rest-spread": "^7.16.7",
             "@babel/plugin-proposal-optional-catch-binding": "^7.16.7",
             "@babel/plugin-proposal-optional-chaining": "^7.16.7",
-            "@babel/plugin-proposal-private-methods": "^7.16.7",
+            "@babel/plugin-proposal-private-methods": "^7.16.11",
             "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
             "@babel/plugin-proposal-unicode-property-regex": "^7.16.7",
             "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -1457,6 +1600,34 @@
             "semver": "^6.3.0"
           }
         },
+        "@babel/traverse": {
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.9.tgz",
+          "integrity": "sha512-PQO8sDIJ8SIwipTPiR71kJQCKQYB5NGImbOviK8K+kg5xkNSYXLBupuX9QhatFowrsvo9Hj8WgArg3W7ijNAQw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.7",
+            "@babel/generator": "^7.17.9",
+            "@babel/helper-environment-visitor": "^7.16.7",
+            "@babel/helper-function-name": "^7.17.9",
+            "@babel/helper-hoist-variables": "^7.16.7",
+            "@babel/helper-split-export-declaration": "^7.16.7",
+            "@babel/parser": "^7.17.9",
+            "@babel/types": "^7.17.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.17.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "babel-plugin-polyfill-corejs2": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.1.tgz",
@@ -1469,13 +1640,13 @@
           }
         },
         "babel-plugin-polyfill-corejs3": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.1.tgz",
-          "integrity": "sha512-TihqEe4sQcb/QcPJvxe94/9RZuLQuF1+To4WqQcRvc+3J3gLCPIPgDKzGLG6zmQLfH3nn25heRuDNkS2KR4I8A==",
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.2.tgz",
+          "integrity": "sha512-G3uJih0XWiID451fpeFaYGVuxHEjzKTHtc9uGFEjR6hHrvNzeS/PX+LLLcetJcytsB5m4j+K3o/EpXJNb/5IEQ==",
           "dev": true,
           "requires": {
             "@babel/helper-define-polyfill-provider": "^0.3.1",
-            "core-js-compat": "^3.20.0"
+            "core-js-compat": "^3.21.0"
           }
         },
         "babel-plugin-polyfill-regenerator": {
@@ -1493,6 +1664,49 @@
           "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
           "dev": true
         },
+        "caniuse-lite": {
+          "version": "1.0.30001332",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
+          "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+          "dev": true
+        },
+        "core-js-compat": {
+          "version": "3.22.2",
+          "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.2.tgz",
+          "integrity": "sha512-Fns9lU06ZJ07pdfmPMu7OnkIKGPKDzXKIiuGlSvHHapwqMUF2QnnsWwtueFZtSyZEilP0o6iUeHQwpn7LxtLUw==",
+          "dev": true,
+          "requires": {
+            "browserslist": "^4.20.2",
+            "semver": "7.0.0"
+          },
+          "dependencies": {
+            "browserslist": {
+              "version": "4.20.3",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+              "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+              "dev": true,
+              "requires": {
+                "caniuse-lite": "^1.0.30001332",
+                "electron-to-chromium": "^1.4.118",
+                "escalade": "^3.1.1",
+                "node-releases": "^2.0.3",
+                "picocolors": "^1.0.0"
+              }
+            },
+            "semver": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+              "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+              "dev": true
+            }
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.4.119",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.119.tgz",
+          "integrity": "sha512-HPEmKy+d0xK8oCfEHc5t6wDsSAi1WmE3Ld08QrBjAPxaAzfuKP66VJ77lcTqxTt7GJmSE279s75mhW64Xh+4kw==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "9.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -1505,6 +1719,12 @@
             "universalify": "^2.0.0"
           }
         },
+        "json5": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+          "dev": true
+        },
         "jsonfile": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -1514,6 +1734,12 @@
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
           }
+        },
+        "node-releases": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
+          "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw==",
+          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -2086,6 +2312,28 @@
         "chalk": "^4.0.0"
       }
     },
+    "@jridgewell/resolve-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
+      "integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
+      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@mdn/browser-compat-data": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-2.0.7.tgz",
@@ -2395,9 +2643,9 @@
       }
     },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz",
-      "integrity": "sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
       "dev": true
     },
     "@types/sizzle": {
@@ -2440,9 +2688,9 @@
       "dev": true
     },
     "@types/yauzl": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
-      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -2802,6 +3050,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "minimist": {
@@ -4088,8 +4342,7 @@
     },
     "ansi-regex": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "resolved": "",
       "dev": true
     },
     "ansi-styles": {
@@ -5612,9 +5865,9 @@
       }
     },
     "cached-path-relative": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
-      "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.1.0.tgz",
+      "integrity": "sha512-WF0LihfemtesFcJgO7xfOoOcnWzY/QHR4qeDqV44jPU3HTI54+LnfXK3SA27AVVGCdZFgjjFFaqUA9Jx7dMJZA==",
       "dev": true
     },
     "cachedir": {
@@ -5750,15 +6003,16 @@
       "dev": true
     },
     "chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
         "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       }
@@ -5983,12 +6237,12 @@
       }
     },
     "cli-table3": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
-      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
+      "integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
       "dev": true,
       "requires": {
-        "colors": "1.4.0",
+        "@colors/colors": "1.5.0",
         "string-width": "^4.2.0"
       },
       "dependencies": {
@@ -8418,19 +8672,20 @@
       "dev": true
     },
     "cypress": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.2.1.tgz",
-      "integrity": "sha512-LVEe4yWCo4xO0Vd8iYjFHRyd5ulRvM56XqMgAdn05Qb9kJ6iJdO/MmjKD8gNd768698cp1FDuSmFQZHVZGk+Og==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.6.0.tgz",
+      "integrity": "sha512-nNwt9eBQmSENamwa8LxvggXksfyzpyYaQ7lNBLgks3XZ6dPE/6BCQFBzeAyAPt/bNXfH3tKPkAyhiAZPYkWoEg==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
-        "@types/sinonjs__fake-timers": "^6.0.2",
+        "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
-        "bluebird": "3.7.2",
+        "bluebird": "^3.7.2",
+        "buffer": "^5.6.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
@@ -8454,22 +8709,22 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
+        "semver": "^7.3.2",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
-        "url": "^0.11.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.5.tgz",
-          "integrity": "sha512-LMy+vDDcQR48EZdEx5wRX1q/sEl6NdGuHXPnfeL8ixkwCOSZ2qnIyIZmcCbdX0MeRqHhAcHmX+haCbrS8Run+A==",
+          "version": "14.18.15",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.15.tgz",
+          "integrity": "sha512-hzzmpfqOhsFmvQ9nu87qNQJ8ksofJLBIKkgaYWFapV+W8UGHCxtg5uf69ZtlDSS8rb4ax3lMgpqBnLUQETjCJA==",
           "dev": true
         },
         "arch": {
@@ -8489,6 +8744,16 @@
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
           "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
           "dev": true
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
         },
         "cachedir": {
           "version": "2.3.0",
@@ -8663,12 +8928,6 @@
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-          "dev": true
         },
         "log-symbols": {
           "version": "4.1.0",
@@ -8882,9 +9141,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
-      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.1.tgz",
+      "integrity": "sha512-ER7EjqVAMkRRsxNCC5YqJ9d9VQYuWdGt7aiH2qA5R5wt8ZmWaP2dLUSIK6y/kVzLMlmh1Tvu5xUf4M/wdGJ5KA==",
       "dev": true
     },
     "de-indent": {
@@ -9667,9 +9926,9 @@
       }
     },
     "error-stack-parser": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
-      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.7.tgz",
+      "integrity": "sha512-chLOW0ZGRf4s8raLrDxa5sdkvPec5YdvwbFnqJme4rk0rFajP8mPtrDL1+I+CwrQDCjswDA5sREX7jYQDQs9vA==",
       "dev": true,
       "requires": {
         "stackframe": "^1.1.1"
@@ -9715,14 +9974,14 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "version": "0.10.61",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
+      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
       }
     },
     "es6-iterator": {
@@ -10770,9 +11029,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
-          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
           "dev": true
         }
       }
@@ -10876,6 +11135,21 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
           }
         },
         "ms": {
@@ -11183,9 +11457,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true
     },
     "for-in": {
@@ -15179,9 +15453,9 @@
           }
         },
         "rxjs": {
-          "version": "7.5.2",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.2.tgz",
-          "integrity": "sha512-PwDt186XaL3QN5qXj/H9DGyHhP3/RYYgZZwqBv9Tv8rsAaiwFH1IsJJlcgD37J7UW5a6O67qX0KWKS3/pu0m4w==",
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+          "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
           "dev": true,
           "requires": {
             "tslib": "^2.1.0"
@@ -15298,9 +15572,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash._reinterpolate": {
@@ -15464,6 +15738,15 @@
       "requires": {
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
+      }
+    },
+    "loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "dev": true,
+      "requires": {
+        "get-func-name": "^2.0.0"
       }
     },
     "lower-case": {
@@ -15954,9 +16237,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "minimist-options": {
@@ -16045,20 +16328,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
+        "minimist": "^1.2.6"
       }
     },
     "mkdirp-classic": {
@@ -16221,9 +16496,9 @@
       "dev": true
     },
     "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true
     },
     "nice-try": {
@@ -17392,9 +17667,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
           "dev": true,
           "requires": {
             "lodash": "^4.17.14"
@@ -18508,9 +18783,9 @@
       "dev": true
     },
     "prismjs": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.26.0.tgz",
-      "integrity": "sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
+      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==",
       "dev": true
     },
     "process": {
@@ -20780,9 +21055,9 @@
       }
     },
     "stackframe": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
-      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.1.tgz",
+      "integrity": "sha512-h88QkzREN/hy8eRdyNhhsO7RSJ5oyTqxxmmn0dzBIMUclZsjpfmrsg81vp8mjjAs2vAZ72nyWxRUwSwmh0e4xg==",
       "dev": true
     },
     "stacktrace-gps": {
@@ -22002,9 +22277,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "tsutils": {
@@ -22498,9 +22773,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.4.tgz",
-      "integrity": "sha512-ITeAByWWoqutFClc/lRZnFplgXgEZr3WJ6XngMM/N9DMIm4K8zXPCZ1Jdu0rERwO84w1WC5wkle2ubwTA4NTBg==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
@@ -23951,8 +24226,7 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "resolved": "",
               "dev": true
             },
             "strip-ansi": {
@@ -24218,8 +24492,7 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "resolved": "",
               "dev": true
             },
             "strip-ansi": {
@@ -24274,8 +24547,7 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "resolved": "",
               "dev": true
             },
             "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "chalk": "4.1.1",
     "cleave.js": "1.6.0",
     "core-js": "3.12.1",
-    "cypress": "9.2.1",
+    "cypress": "9.6.0",
     "cypress-cucumber-preprocessor": "4.1.4",
     "cypress-plugin-tab": "1.0.5",
     "date-fns": "2.21.3",

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -294,7 +294,7 @@ export default {
       }
     },
     /**
-     * Parses a typed date and submits it, if valid
+     * Parses a typed date and emits `typed-date` event, if valid
      * @param  {object}  event Used to exclude certain keystrokes
      */
     handleKeyup(event) {
@@ -313,15 +313,16 @@ export default {
         return
       }
 
-      if (this.input.value === '') {
+      this.typedDate = this.input.value
+
+      if (!this.input.value) {
         this.$emit('typed-date', null)
         return
       }
 
       const parsedDate = this.parseInput()
 
-      if (!Number.isNaN(parsedDate)) {
-        this.typedDate = this.input.value
+      if (this.utils.isValidDate(parsedDate)) {
         this.$emit('typed-date', parsedDate)
       }
     },

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -301,6 +301,7 @@ export default {
       if (
         !this.typeable ||
         [
+          'Control',
           'Shift',
           'Tab',
           'ArrowUp',

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -309,6 +309,7 @@ export default {
         !this.typeable ||
         [
           'Control',
+          'Escape',
           'Shift',
           'Tab',
           'ArrowUp',

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -119,19 +119,6 @@ export default {
       }
       return this.inputClass
     },
-    formattedDate() {
-      if (!this.selectedDate) {
-        return null
-      }
-
-      return typeof this.format === 'function'
-        ? this.format(new Date(this.selectedDate))
-        : this.utils.formatDate(
-            new Date(this.selectedDate),
-            this.format,
-            this.translation,
-          )
-    },
     formattedValue() {
       if (!this.selectedDate) {
         return null
@@ -139,7 +126,8 @@ export default {
       if (this.typedDate.length) {
         return this.typedDate
       }
-      return this.formattedDate
+
+      return this.formatDate(this.selectedDate)
     },
   },
   watch: {
@@ -176,6 +164,20 @@ export default {
       this.$emit('clear-date')
     },
     /**
+     * Formats a date
+     * @param {Date} date The date to be formatted
+     * @returns {String}
+     */
+    formatDate(date) {
+      if (!date) {
+        return ''
+      }
+
+      return typeof this.format === 'function'
+        ? this.format(new Date(date))
+        : this.utils.formatDate(new Date(date), this.format, this.translation)
+    },
+    /**
      * Formats a typed date, or clears it if invalid
      */
     formatTypedDate() {
@@ -183,7 +185,7 @@ export default {
         this.input.value = ''
         this.typedDate = ''
       } else {
-        this.typedDate = this.formattedDate
+        this.typedDate = this.formatDate(this.typedDate)
       }
     },
     /**

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -119,10 +119,7 @@ export default {
       return this.inputClass
     },
     formattedValue() {
-      if (!this.selectedDate) {
-        return null
-      }
-      if (this.typedDate.length) {
+      if (this.typeable) {
         return this.typedDate
       }
 

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -182,11 +182,11 @@ export default {
     formatTypedDate() {
       const parsedDate = this.parseInput()
 
-      if (Number.isNaN(parsedDate)) {
+      if (this.utils.isValidDate(parsedDate)) {
+        this.typedDate = this.formatDate(parsedDate)
+      } else {
         this.input.value = ''
         this.typedDate = ''
-      } else {
-        this.typedDate = this.formatDate(parsedDate)
       }
     },
     /**

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -264,17 +264,22 @@ export default {
       this.$emit('set-focus', ['prev', 'up', 'next', 'tabbableCell'])
     },
     /**
-     * Formats a typed date and closes the calendar
+     * Selects a typed date and closes the calendar
      */
     handleKeydownEnter() {
       if (!this.typeable) {
         return
       }
 
-      this.formatTypedDate()
+      if (!this.input.value) {
+        this.$emit('select-typed-date', null)
+        return
+      }
 
-      if (this.isOpen) {
-        this.$emit('close')
+      const parsedDate = this.parseInput()
+
+      if (this.utils.isValidDate(parsedDate)) {
+        this.$emit('select-typed-date', new Date(parsedDate))
       }
     },
     /**

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -150,6 +150,11 @@ export default {
         }
       })
     },
+    selectedDate(selectedDate) {
+      if (this.typeable) {
+        this.typedDate = this.formatDate(selectedDate)
+      }
+    },
   },
   mounted() {
     this.input = this.$el.querySelector('input')

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -104,7 +104,6 @@ export default {
       isInputFocused: false,
       shouldToggleOnFocus: false,
       shouldToggleOnClick: true,
-      parsedDate: null,
       typedDate: '',
       utils: makeDateUtils(this.useUtc),
     }
@@ -181,11 +180,13 @@ export default {
      * Formats a typed date, or clears it if invalid
      */
     formatTypedDate() {
-      if (Number.isNaN(this.parsedDate)) {
+      const parsedDate = this.parseInput()
+
+      if (Number.isNaN(parsedDate)) {
         this.input.value = ''
         this.typedDate = ''
       } else {
-        this.typedDate = this.formatDate(this.typedDate)
+        this.typedDate = this.formatDate(parsedDate)
       }
     },
     /**
@@ -316,18 +317,11 @@ export default {
         return
       }
 
-      this.parsedDate = Date.parse(
-        this.utils.parseDate(
-          this.input.value,
-          this.format,
-          this.translation,
-          this.parser,
-        ),
-      )
+      const parsedDate = this.parseInput()
 
-      if (!Number.isNaN(this.parsedDate)) {
+      if (!Number.isNaN(parsedDate)) {
         this.typedDate = this.input.value
-        this.$emit('typed-date', new Date(this.parsedDate))
+        this.$emit('typed-date', parsedDate)
       }
     },
     /**
@@ -345,6 +339,19 @@ export default {
       if (!this.showCalendarOnButtonClick) {
         this.toggle()
       }
+    },
+    /**
+     * Parses the value of the input field
+     */
+    parseInput() {
+      return new Date(
+        this.utils.parseDate(
+          this.input.value.trim(),
+          this.format,
+          this.translation,
+          this.parser,
+        ),
+      )
     },
     /**
      * Opens or closes the calendar

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -641,6 +641,7 @@ export default {
     },
     /**
      * Sets the date that the calendar should open on
+     * @param {Date=} date The date to set for the page
      */
     setPageDate(date) {
       let dateTemp = date

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -651,14 +651,9 @@ export default {
      * @param {Number} timestamp
      */
     selectDate(timestamp) {
-      if (!timestamp) {
-        this.selectedDate = null
-        return
-      }
-
       const date = new Date(timestamp)
-      this.selectedDate = date
-      this.setPageDate(date)
+
+      this.setValue(date)
       this.$emit('selected', date)
       this.$emit('input', date)
     },

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -493,16 +493,29 @@ export default {
       }
     },
     /**
-     * Set the date from a 'typed-date' event
-     * @param {Date} date
+     * Updates the page (if necessary) after a 'typed-date' event and sets `tabbableCell` & `latestValidTypedDate`
+     * @param {Date=} date
      */
     handleTypedDate(date) {
-      if (this.selectedDate) {
-        this.setTransitionAndFocusDelay(this.selectedDate, date)
+      if (!date) {
+        return
       }
 
-      this.selectDate(date ? date.valueOf() : null)
-      this.reviewFocus()
+      const originalPageDateValue = new Date(this.pageDate)
+
+      this.setTransitionAndFocusDelay(this.latestValidTypedDate, date)
+      this.latestValidTypedDate = date
+      this.setPageDate(date)
+
+      if (this.isPageChange(originalPageDateValue)) {
+        this.handlePageChange({
+          focusRefs: [],
+          pageDate: this.pageDate,
+        })
+        return
+      }
+
+      this.setTabbableCell()
     },
     /**
      * Focus the relevant element when the view changes
@@ -532,6 +545,18 @@ export default {
      */
     hasClass(element, className) {
       return element && element.className.split(' ').includes(className)
+    },
+    /**
+     * Used for typeable datepicker: returns true if a typed date causes the page to change
+     * @param   {Date}    originalPageDate
+     * @returns {Boolean}
+     */
+    isPageChange(originalPageDate) {
+      if (!this.isOpen) {
+        return false
+      }
+
+      return originalPageDate.valueOf() !== this.pageDate.valueOf()
     },
     /**
      * Initiate the component

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -501,17 +501,17 @@ export default {
      * @param {Date=} date
      */
     handleTypedDate(date) {
-      if (!date) {
-        return
-      }
+      const originalTypedDate = new Date(this.latestValidTypedDate)
+      const originalPageDate = new Date(this.pageDate)
 
-      const originalPageDateValue = new Date(this.pageDate)
-
-      this.setTransitionAndFocusDelay(this.latestValidTypedDate, date)
-      this.latestValidTypedDate = date
+      this.latestValidTypedDate = date || this.computedOpenDate
+      this.setTransitionAndFocusDelay(
+        originalTypedDate,
+        this.latestValidTypedDate,
+      )
       this.setPageDate(date)
 
-      if (this.isPageChange(originalPageDateValue)) {
+      if (this.isPageChange(originalPageDate)) {
         this.handlePageChange({
           focusRefs: [],
           pageDate: this.pageDate,

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -510,6 +510,7 @@ export default {
         this.latestValidTypedDate,
       )
       this.setPageDate(date)
+      this.$emit('input', date)
 
       if (this.isPageChange(originalPageDate)) {
         this.handlePageChange({
@@ -669,7 +670,6 @@ export default {
       this.setValue(date)
       this.reviewFocus()
       this.$emit('selected', date)
-      this.$emit('input', date)
 
       if (this.isOpen) {
         this.close()

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -681,18 +681,11 @@ export default {
      * @param {Date|String|Number|null} date
      */
     setValue(date) {
-      if (!date) {
-        this.selectedDate = null
-        this.setPageDate()
-        if (this.typeable) {
-          this.latestValidTypedDate = this.computedOpenDate
-        }
-        return
-      }
-      this.selectedDate = date
+      this.selectedDate = date || null
       this.setPageDate(date)
+
       if (this.typeable) {
-        this.latestValidTypedDate = date
+        this.latestValidTypedDate = date || this.computedOpenDate
       }
     },
     /**

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -748,7 +748,8 @@ export default {
       }
     },
     /**
-     * Set the datepicker value (and, if typeable, update `latestValidTypedDate`)     * @param {Date|String|Number|null} date
+     * Set the datepicker value (and, if typeable, update `latestValidTypedDate`)
+     * @param {Date|String|Number|null} date
      */
     setValue(date) {
       this.selectedDate = date || null

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -353,10 +353,14 @@ export default {
         this.setInitialView()
       }
     },
-    isActive(hasJustBecomeActive) {
+    isActive(hasJustBecomeActive, isNoLongerActive) {
       if (hasJustBecomeActive && this.inline) {
         this.setNavElementsFocusedIndex()
         this.tabToCorrectInlineCell()
+      }
+
+      if (isNoLongerActive && this.typeable) {
+        this.setTypedDateOnLosingFocus()
       }
     },
     latestValidTypedDate(date) {
@@ -721,8 +725,30 @@ export default {
       this.slideDuration = parseFloat(durationInSecs) * 1000
     },
     /**
-     * Set the datepicker value (and, if typeable, update `latestValidTypedDate`)
-     * @param {Date|String|Number|null} date
+     * Selects the typed date when the datepicker loses focus, provided it's valid and differs from the current selected date
+     */
+    setTypedDateOnLosingFocus() {
+      const parsedDate = this.$refs.dateInput.parseInput()
+      const date = this.utils.isValidDate(parsedDate) ? parsedDate : null
+      const hasChanged = () => {
+        if (!this.selectedDate && !date) {
+          return false
+        }
+
+        if (this.selectedDate && date) {
+          return date.valueOf() !== this.selectedDate.valueOf()
+        }
+
+        return true
+      }
+
+      if (hasChanged()) {
+        this.setValue(date)
+        this.$emit('selected', date)
+      }
+    },
+    /**
+     * Set the datepicker value (and, if typeable, update `latestValidTypedDate`)     * @param {Date|String|Number|null} date
      */
     setValue(date) {
       this.selectedDate = date || null

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -251,6 +251,11 @@ export default {
       calendarSlots,
       isClickOutside: false,
       /*
+       * The latest valid `typedDate` (used for typeable datepicker)
+       * {Date}
+       */
+      latestValidTypedDate: null,
+      /*
        * Vue cannot observe changes to a Date Object so date must be stored as a timestamp
        * This represents the first day of the current viewing month
        * {Number}
@@ -527,6 +532,7 @@ export default {
     /**
      * Initiate the component
      */
+    // eslint-disable-next-line complexity,max-statements
     init() {
       if (this.value) {
         let parsedValue = this.parseValue(this.value)
@@ -537,6 +543,8 @@ export default {
           this.$emit('input', parsedValue)
         }
         this.setValue(parsedValue)
+      } else if (this.typeable) {
+        this.latestValidTypedDate = this.utils.getNewDateObject()
       }
 
       if (this.isInline) {
@@ -669,17 +677,23 @@ export default {
       this.slideDuration = parseFloat(durationInSecs) * 1000
     },
     /**
-     * Set the datepicker value
+     * Set the datepicker value (and, if typeable, update `latestValidTypedDate`)
      * @param {Date|String|Number|null} date
      */
     setValue(date) {
       if (!date) {
         this.selectedDate = null
         this.setPageDate()
+        if (this.typeable) {
+          this.latestValidTypedDate = this.computedOpenDate
+        }
         return
       }
       this.selectedDate = date
       this.setPageDate(date)
+      if (this.typeable) {
+        this.latestValidTypedDate = date
+      }
     },
     /**
      * Set the picker view

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -43,6 +43,7 @@
       @close="close"
       @focus="handleInputFocus"
       @open="open"
+      @select-typed-date="selectTypedDate"
       @set-focus="setFocus($event)"
       @typed-date="handleTypedDate"
     >
@@ -632,6 +633,20 @@ export default {
       this.setPageDate(date)
       this.$emit('selected', date)
       this.$emit('input', date)
+    },
+    /**
+     * Select the date from a 'select-typed-date' event
+     * @param {Date=} date
+     */
+    selectTypedDate(date) {
+      this.setValue(date)
+      this.reviewFocus()
+      this.$emit('selected', date)
+      this.$emit('input', date)
+
+      if (this.isOpen) {
+        this.close()
+      }
     },
     /**
      * Sets the initial picker page view: day, month or year

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -359,6 +359,9 @@ export default {
         this.tabToCorrectInlineCell()
       }
     },
+    latestValidTypedDate(date) {
+      this.setPageDate(date)
+    },
     openDate() {
       this.setPageDate()
     },

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -678,9 +678,15 @@ export default {
           dateTemp = new Date()
         }
       }
-      dateTemp = this.utils.resetDateTime(new Date(dateTemp))
 
-      this.pageTimestamp = this.utils.setDate(new Date(dateTemp), 1)
+      let pageTimestamp = this.utils.resetDateTime(new Date(dateTemp))
+      pageTimestamp = this.utils.setDate(new Date(pageTimestamp), 1)
+
+      if (this.view === 'year') {
+        pageTimestamp = this.utils.setMonth(new Date(pageTimestamp), 0)
+      }
+
+      this.pageTimestamp = pageTimestamp
     },
     /**
      * Sets the slide duration in milliseconds by looking up the stylesheet

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -338,10 +338,8 @@ const utils = {
 
   getTime() {
     const time = 'T00:00:00'
-    if (this.useUtc) {
-      return `${time}Z`
-    }
-    return time
+
+    return this.useUtc ? `${time}Z` : time
   },
 
   /**

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -44,10 +44,8 @@ const getParsableDate = ({ formatStr, dateStr, translation, time }) => {
  * @return {Date | String}
  */
 function parseDateWithLibrary(dateStr, parser) {
-  if (!parser || typeof parser !== 'function') {
-    throw new Error(
-      'Parser needs to be a function if you are using a custom formatter',
-    )
+  if (typeof parser !== 'function') {
+    throw new Error('Parser needs to be a function')
   }
 
   return parser(dateStr)
@@ -318,7 +316,7 @@ const utils = {
       return dateStr
     }
 
-    if (typeof formatStr === 'function') {
+    if (parser) {
       return parseDateWithLibrary(dateStr, parser)
     }
 

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -287,16 +287,16 @@ const utils = {
     const day = this.getDate(date)
 
     const matches = {
-      dd: `0${day}`.slice(-2),
       d: day,
-      yyyy: year,
-      yy: String(year).slice(2),
-      MMMM: this.getMonthName(this.getMonth(date), translation.months),
-      MMM: this.getMonthNameAbbr(this.getMonth(date), translation.monthsAbbr),
-      MM: `0${month}`.slice(-2),
-      M: month,
-      o: this.getNthSuffix(this.getDate(date)),
+      dd: `0${day}`.slice(-2),
       E: this.getDayNameAbbr(date, translation.days),
+      o: this.getNthSuffix(this.getDate(date)),
+      M: month,
+      MM: `0${month}`.slice(-2),
+      MMM: this.getMonthNameAbbr(this.getMonth(date), translation.monthsAbbr),
+      MMMM: this.getMonthName(this.getMonth(date), translation.months),
+      yy: String(year).slice(2),
+      yyyy: year,
     }
 
     const REGEX_FORMAT = /y{4}|y{2}|M{1,4}(?![aäe])|d{1,2}|o|E(?![eéi])/g

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -299,8 +299,9 @@ const utils = {
       yyyy: year,
     }
 
-    const REGEX_FORMAT = /y{4}|y{2}|M{1,4}(?![aäe])|d{1,2}|o|E(?![eéi])/g
-    return formatStr.replace(REGEX_FORMAT, (match) => matches[match] || match)
+    const REGEX_FORMAT = /y{4}|y{2}|M{1,4}|d{1,2}|o|E/g
+
+    return formatStr.replace(REGEX_FORMAT, (match) => matches[match])
   },
 
   /**

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -2,14 +2,14 @@ import en from '~/locale/translations/en'
 
 /**
  * Attempts to return a parseable date in the format 'yyyy-MM-dd'
- * @param {String} formatStr
  * @param {String} dateStr
+ * @param {String} formatStr
  * @param {Object} translation
  * @param {String} time
  * @return String
  */
 // eslint-disable-next-line complexity,max-statements
-const getParsableDate = ({ formatStr, dateStr, translation, time }) => {
+const getParsableDate = ({ dateStr, formatStr, translation, time }) => {
   const splitter = formatStr.match(/-|\/|\s|\./) || ['-']
   const df = formatStr.split(splitter[0])
   const ds = dateStr.split(splitter[0])
@@ -39,13 +39,18 @@ const getParsableDate = ({ formatStr, dateStr, translation, time }) => {
 
 /**
  * Parses a date using a function passed in via the `parser` prop
- * @param  {Function}      parser  The function that should be used to parse the date
- * @param  {String}        dateStr The string to parse
+ * @param  {String}   dateStr The string to parse
+ * @param  {Function} format  The function that should be used to format the date
+ * @param  {Function} parser  The function that should be used to parse the date
  * @return {Date | String}
  */
-function parseDateWithLibrary(dateStr, parser) {
+function parseDateWithLibrary(dateStr, format, parser) {
   if (typeof parser !== 'function') {
     throw new Error('Parser needs to be a function')
+  }
+
+  if (typeof format !== 'function') {
+    throw new Error('Format needs to be a function when using a custom parser')
   }
 
   return parser(dateStr)
@@ -305,24 +310,24 @@ const utils = {
   /**
    * Parses a date from a string, or returns the original string
    * @param {String}          dateStr
-   * @param {String|Function} formatStr
+   * @param {String|Function} format
    * @param {Object}          translation
    * @param {Function}        parser
    * @return {Date | String}
    */
   // eslint-disable-next-line max-params
-  parseDate(dateStr, formatStr, translation = en, parser = null) {
-    if (!(dateStr && formatStr)) {
+  parseDate(dateStr, format, translation = en, parser = null) {
+    if (!(dateStr && format)) {
       return dateStr
     }
 
     if (parser) {
-      return parseDateWithLibrary(dateStr, parser)
+      return parseDateWithLibrary(dateStr, format, parser)
     }
 
     const parseableDate = getParsableDate({
-      formatStr,
       dateStr,
+      formatStr: format,
       translation,
       time: this.getTime(),
     })

--- a/test/unit/specs/DateInput/DateInput.spec.js
+++ b/test/unit/specs/DateInput/DateInput.spec.js
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils'
+import { format } from 'date-fns'
 import DateInput from '~/components/DateInput.vue'
 import { en } from '~/locale'
 
@@ -47,13 +48,15 @@ describe('DateInput', () => {
 
   it('delegates date formatting', async () => {
     await wrapper.setProps({
-      selectedDate: new Date(2016, 1, 15),
-      format: () => '2016/1/15',
+      selectedDate: new Date(2016, 0, 15),
+      format: (date) => {
+        return format(new Date(date), 'dd.MM.yyyy')
+      },
     })
 
     const input = wrapper.find('input')
 
-    expect(input.element.value).toEqual('2016/1/15')
+    expect(input.element.value).toEqual('15.01.2016')
   })
 
   it('emits `open` event on focus when `show-calendar-on-focus` is true', async () => {

--- a/test/unit/specs/DateInput/DateInput.spec.js
+++ b/test/unit/specs/DateInput/DateInput.spec.js
@@ -12,17 +12,13 @@ describe('DateInput unmounted', () => {
 describe('DateInput', () => {
   let wrapper
 
-  const createWrapper = () => {
-    return shallowMount(DateInput, {
+  beforeEach(() => {
+    wrapper = shallowMount(DateInput, {
       propsData: {
         selectedDate: new Date(2018, 2, 24),
         translation: en,
       },
     })
-  }
-
-  beforeEach(() => {
-    wrapper = createWrapper()
   })
 
   afterEach(() => {
@@ -33,18 +29,20 @@ describe('DateInput', () => {
     expect(wrapper.findAll('input')).toHaveLength(1)
   })
 
-  it('nulls date', async () => {
+  it('clears the date', async () => {
     await wrapper.setProps({
       selectedDate: null,
     })
 
-    expect(wrapper.vm.formattedValue).toBeNull()
-    expect(wrapper.find('input').element.value).toEqual('')
+    const input = wrapper.find('input')
+
+    expect(input.element.value).toEqual('')
   })
 
   it('formats date', () => {
-    expect(wrapper.vm.formattedValue).toEqual('24 Mar 2018')
-    expect(wrapper.find('input').element.value).toEqual('24 Mar 2018')
+    const input = wrapper.find('input')
+
+    expect(input.element.value).toEqual('24 Mar 2018')
   })
 
   it('delegates date formatting', async () => {
@@ -53,31 +51,29 @@ describe('DateInput', () => {
       format: () => '2016/1/15',
     })
 
-    expect(wrapper.vm.formattedValue).toEqual('2016/1/15')
-    expect(wrapper.find('input').element.value).toEqual('2016/1/15')
+    const input = wrapper.find('input')
+
+    expect(input.element.value).toEqual('2016/1/15')
   })
 
-  it('opens calendar on focus when `show-calendar-on-focus` is true', async () => {
+  it('emits `open` event on focus when `show-calendar-on-focus` is true', async () => {
     await wrapper.setProps({
       showCalendarOnFocus: true,
     })
 
     const input = wrapper.find('input')
 
-    expect(wrapper.vm.isOpen).toBeFalsy()
-
     await input.trigger('focus')
 
     expect(wrapper.emitted('open')).toBeTruthy()
   })
 
-  it('does not open calendar on focus, if show-calendar-on-focus prop is false', async () => {
-    const input = wrapper.find('input')
+  it('does not emit `open` event on focus when show-calendar-on-focus prop is false', async () => {
     await wrapper.setProps({
       showCalendarOnFocus: false,
     })
 
-    expect(wrapper.vm.isOpen).toBeFalsy()
+    const input = wrapper.find('input')
 
     await input.trigger('focus')
 
@@ -112,9 +108,9 @@ describe('DateInput', () => {
 
     const input = wrapper.find('input')
 
-    expect(wrapper.vm.isOpen).toBeFalsy()
     await input.trigger('focus')
     await input.trigger('click')
+
     expect(wrapper.emitted('open')).toBeTruthy()
   })
 
@@ -123,7 +119,9 @@ describe('DateInput', () => {
       bootstrapStyling: true,
     })
 
-    expect(wrapper.find('input').element.classList).toContain('form-control')
+    const input = wrapper.find('input')
+
+    expect(input.element.classList).toContain('form-control')
   })
 
   it('appends bootstrap classes', async () => {
@@ -132,16 +130,18 @@ describe('DateInput', () => {
       bootstrapStyling: true,
     })
 
-    expect(wrapper.find('input').element.classList).toContain('form-control')
-    expect(wrapper.find('input').element.classList).toContain('someClass')
+    const input = wrapper.find('input')
+
+    expect(input.element.classList).toContain('form-control')
+    expect(input.element.classList).toContain('someClass')
 
     await wrapper.setProps({
       inputClass: { someClass: true },
       bootstrapStyling: true,
     })
 
-    expect(wrapper.find('input').element.classList).toContain('form-control')
-    expect(wrapper.find('input').element.classList).toContain('someClass')
+    expect(input.element.classList).toContain('form-control')
+    expect(input.element.classList).toContain('someClass')
   })
 
   it('can be disabled', async () => {
@@ -149,7 +149,9 @@ describe('DateInput', () => {
       disabled: true,
     })
 
-    expect(wrapper.find('input').attributes().disabled).toBeDefined()
+    const input = wrapper.find('input')
+
+    expect(input.attributes().disabled).toBeDefined()
   })
 
   it('accepts a function as a formatter', async () => {
@@ -157,7 +159,9 @@ describe('DateInput', () => {
       format: () => '!',
     })
 
-    expect(wrapper.find('input').element.value).toEqual('!')
+    const input = wrapper.find('input')
+
+    expect(input.element.value).toEqual('!')
   })
 
   it('emits `close` when escape is pressed and calendar is open', async () => {
@@ -171,22 +175,23 @@ describe('DateInput', () => {
     expect(wrapper.emitted('close')).toBeTruthy()
   })
 
-  it('opens the calendar on click', async () => {
+  it('emits `open` event on click', async () => {
     const input = wrapper.find('input')
     await input.trigger('click')
 
     expect(wrapper.emitted('open')).toBeTruthy()
   })
 
-  it('opens the calendar when the space bar is pressed on the input field', async () => {
+  it('emits `open` event when the space bar is pressed on the input field', async () => {
     const input = wrapper.find('input')
+
     await input.trigger('keydown.space')
     await input.trigger('keyup.space')
 
     expect(wrapper.emitted('open')).toBeTruthy()
   })
 
-  it('opens the calendar on focus', async () => {
+  it('emits `open` event on focus when `showCalendarOnFocus` is true', async () => {
     const input = wrapper.find('input')
     await input.trigger('focus')
 
@@ -201,11 +206,12 @@ describe('DateInput', () => {
   })
 
   it('opens ONLY on button click when the relevant prop is set', async () => {
-    const input = wrapper.find('input')
     await wrapper.setProps({
       calendarButton: true,
       showCalendarOnButtonClick: true,
     })
+
+    const input = wrapper.find('input')
     await input.trigger('click')
 
     expect(wrapper.emitted('open')).toBeFalsy()
@@ -220,6 +226,7 @@ describe('DateInput', () => {
     const input = wrapper.find('input')
 
     await input.trigger('keydown.del')
+
     expect(wrapper.emitted('clear-date')).toBeTruthy()
   })
 
@@ -227,6 +234,7 @@ describe('DateInput', () => {
     const input = wrapper.find('input')
 
     await input.trigger('keydown.backspace')
+
     expect(wrapper.emitted('clear-date')).toBeTruthy()
   })
 })

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -1,5 +1,5 @@
 import { mount, shallowMount } from '@vue/test-utils'
-import { format, parse } from 'date-fns'
+import { parse } from 'date-fns'
 import DateInput from '~/components/DateInput.vue'
 import Datepicker from '~/components/Datepicker.vue'
 import { en } from '~/locale'
@@ -88,24 +88,6 @@ describe('DateInput', () => {
     await input.trigger('keydown.enter')
 
     expect(input.element.value).toEqual(dateString)
-  })
-
-  it('allows function format', async () => {
-    const dateString = '2018-08-12'
-
-    await wrapper.setProps({
-      selectedDate: new Date(dateString),
-      format: (date) => {
-        return format(new Date(date), 'dd.MM.yyyy')
-      },
-      parser: (date) => {
-        return parse(date, 'yyyy-MM-dd', new Date())
-      },
-    })
-
-    const input = wrapper.find('input')
-
-    expect(input.element.value).toEqual('12.08.2018')
   })
 
   it('emits the date when typed', async () => {
@@ -295,25 +277,6 @@ describe('Datepicker mount', () => {
     await input.trigger('keyup.space')
 
     expect(wrapper.vm.isOpen).toBeTruthy()
-  })
-
-  it('formats a date using function format', async () => {
-    await wrapper.setProps({
-      format: (date) => {
-        return format(new Date(date), 'dd.MM.yyyy')
-      },
-      parser: (date) => {
-        return parse(date, 'yyyy-MM-dd', new Date())
-      },
-    })
-
-    const input = wrapper.find('input')
-
-    input.setValue('2018-08-12')
-    await input.trigger('keyup')
-    await input.trigger('keydown.enter')
-
-    expect(input.element.value).toEqual('12.08.2018')
   })
 })
 

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -21,110 +21,130 @@ describe('DateInput', () => {
   })
 
   it('does not format the date when typed', async () => {
+    const input = wrapper.find('input')
     const dateString = '2018-04-24'
-    wrapper.vm.input.value = dateString
-    expect(wrapper.vm.input.value).toEqual(dateString)
-    await wrapper.setData({
-      typedDate: dateString,
-    })
+
+    input.setValue(dateString)
+    await input.trigger('keyup')
+
+    expect(input.element.value).toEqual(dateString)
+  })
+
+  it('allows international custom date format dd.MM.yyyy', async () => {
     await wrapper.setProps({
-      selectedDate: new Date(dateString),
+      format: 'dd.MM.yyyy',
     })
-    expect(wrapper.vm.typedDate).toEqual(dateString)
-    expect(wrapper.vm.formattedValue).toEqual(dateString)
+
+    const input = wrapper.find('input')
+    const dateString = '04.06.2018'
+
+    input.setValue(dateString)
+    await input.trigger('keyup')
+    await input.trigger('keydown.enter')
+
+    expect(input.element.value).toEqual(dateString)
   })
 
   it('allows international custom date format d.M.yyyy', async () => {
-    const dateString = '24.06.2018'
     await wrapper.setProps({
-      selectedDate: new Date(dateString),
-      typeable: true,
       format: 'd.M.yyyy',
     })
+
     const input = wrapper.find('input')
-    wrapper.vm.input.value = dateString
-    expect(wrapper.vm.input.value).toEqual(dateString)
+    const dateString = '4.6.2018'
+
+    input.setValue(dateString)
     await input.trigger('keyup')
-    expect(wrapper.vm.formattedValue).toEqual(dateString)
+    await input.trigger('keydown.enter')
+
+    expect(input.element.value).toEqual(dateString)
   })
 
   it('allows international custom date format dd/MM/yyyy', async () => {
-    const dateString = '24/06/2018'
     await wrapper.setProps({
-      selectedDate: new Date(dateString),
-      typeable: true,
       format: 'dd/MM/yyyy',
     })
+
     const input = wrapper.find('input')
-    wrapper.vm.input.value = dateString
-    expect(wrapper.vm.input.value).toEqual(dateString)
+    const dateString = '24/06/2018'
+
+    input.setValue(dateString)
     await input.trigger('keyup')
-    expect(wrapper.vm.formattedValue).toEqual(dateString)
+    await input.trigger('keydown.enter')
+
+    expect(input.element.value).toEqual(dateString)
   })
 
   it('allows international custom date format dd MM yyyy', async () => {
-    const dateString = '24 06 2018'
     await wrapper.setProps({
-      selectedDate: new Date(dateString),
-      typeable: true,
       format: 'dd MM yyyy',
     })
+
     const input = wrapper.find('input')
-    wrapper.vm.input.value = dateString
-    expect(wrapper.vm.input.value).toEqual(dateString)
+    const dateString = '24 06 2018'
+
+    input.setValue(dateString)
     await input.trigger('keyup')
-    expect(wrapper.vm.formattedValue).toEqual(dateString)
+    await input.trigger('keydown.enter')
+
+    expect(input.element.value).toEqual(dateString)
   })
 
   it('allows function format', async () => {
     const dateString = '2018-08-12'
+
     await wrapper.setProps({
       selectedDate: new Date(dateString),
-      typeable: true,
-      format(date) {
+      format: (date) => {
         return format(new Date(date), 'dd.MM.yyyy')
       },
-      parser(date) {
-        return parse(date, 'dd.MM.yyyy', new Date())
+      parser: (date) => {
+        return parse(date, 'yyyy-MM-dd', new Date())
       },
     })
+
     const input = wrapper.find('input')
-    input.setValue(dateString)
-    expect(input.element.value).toEqual(dateString)
-    input.trigger('keyup')
-    expect(wrapper.vm.formattedValue).toEqual('12.08.2018')
+
+    expect(input.element.value).toEqual('12.08.2018')
   })
 
   it('emits the date when typed', async () => {
     const input = wrapper.find('input')
-    input.setValue('2018-04-24')
+    const dateString = '2018-04-24'
+
+    input.setValue(dateString)
     await input.trigger('keyup')
+
     expect(wrapper.emitted('typed-date')).toBeDefined()
-    expect(wrapper.emitted('typed-date')[0][0]).toBeInstanceOf(Date)
+    expect(wrapper.emitted('typed-date')[0][0]).toStrictEqual(
+      new Date(dateString),
+    )
   })
 
-  it('emits `close` when the calendar is open and return is pressed', async () => {
+  it('emits `close` when the calendar is open and enter is pressed', async () => {
     await wrapper.setProps({
       isOpen: true,
     })
 
     const input = wrapper.find('input')
+
     await input.trigger('keydown.enter')
+
     expect(wrapper.emitted('close')).toBeTruthy()
   })
 
   it("doesn't emit the date if typeable=false", async () => {
-    const wrapperNotTypeAble = shallowMount(DateInput, {
-      propsData: {
-        translation: en,
-        typeable: false,
-      },
+    await wrapper.setProps({
+      typeable: false,
     })
-    const input = wrapperNotTypeAble.find('input')
+
+    const input = wrapper.find('input')
+
     input.setValue('2018-04-24')
     await input.trigger('keyup')
     await input.trigger('keydown.enter')
-    expect(wrapperNotTypeAble.emitted('typedDate')).not.toBeDefined()
+
+    expect(wrapper.emitted('typed-date')).not.toBeDefined()
   })
 })
 
@@ -145,19 +165,19 @@ describe('Datepicker mount', () => {
 
   it('sets the date on typedDate event', () => {
     const today = new Date()
+
     wrapper.vm.handleTypedDate(today)
+
     expect(wrapper.vm.selectedDate).toEqual(today)
   })
 
   it('shows the correct month as you type', async () => {
-    const spySelectDate = jest.spyOn(wrapper.vm, 'selectDate')
     const input = wrapper.find('input')
 
     await input.trigger('click')
     input.setValue('Jan')
     await input.trigger('keyup')
 
-    expect(spySelectDate).toHaveBeenCalled()
     expect(wrapper.vm.isOpen).toBeTruthy()
     expect(new Date(wrapper.vm.pageDate).getMonth()).toBe(0)
 
@@ -169,6 +189,7 @@ describe('Datepicker mount', () => {
 
   it('formats a valid date when the input field is blurred', async () => {
     const input = wrapper.find('input')
+
     input.setValue('2018-04-24')
     await input.trigger('keyup')
     await input.trigger('blur')
@@ -222,10 +243,12 @@ describe('Datepicker mount', () => {
 
   it('resets the date correctly', async () => {
     const input = wrapper.find('input')
+
     await input.trigger('click')
     input.setValue('1 Jan 2000')
     await input.trigger('keyup')
     await input.trigger('keydown.enter')
+
     expect(wrapper.vm.selectedDate).toEqual(new Date(2000, 0, 1))
 
     await wrapper.setProps({
@@ -247,10 +270,30 @@ describe('Datepicker mount', () => {
 
   it('opens the calendar when the space bar is pressed on the input field', async () => {
     const input = wrapper.find('input')
+
     await input.trigger('keydown.space')
     await input.trigger('keyup.space')
 
     expect(wrapper.vm.isOpen).toBeTruthy()
+  })
+
+  it('formats a date using function format', async () => {
+    await wrapper.setProps({
+      format: (date) => {
+        return format(new Date(date), 'dd.MM.yyyy')
+      },
+      parser: (date) => {
+        return parse(date, 'yyyy-MM-dd', new Date())
+      },
+    })
+
+    const input = wrapper.find('input')
+
+    input.setValue('2018-08-12')
+    await input.trigger('keyup')
+    await input.trigger('keydown.enter')
+
+    expect(input.element.value).toEqual('12.08.2018')
   })
 })
 

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -321,6 +321,8 @@ describe('Datepicker mounted to document body', () => {
   let wrapper
 
   beforeEach(() => {
+    jest.useFakeTimers()
+
     wrapper = mount(Datepicker, {
       attachTo: document.body,
       propsData: {
@@ -330,6 +332,8 @@ describe('Datepicker mounted to document body', () => {
   })
 
   afterEach(() => {
+    jest.clearAllTimers()
+
     wrapper.destroy()
   })
 
@@ -390,5 +394,48 @@ describe('Datepicker mounted to document body', () => {
     await upButton.trigger('keydown.up')
 
     expect(document.activeElement).toBe(input.element)
+  })
+
+  it("selects the typed date when the calendar loses focus, provided it's valid and differs from the current selected date", async () => {
+    const input = wrapper.find('input')
+
+    // Invalid date
+    await input.trigger('click')
+    jest.advanceTimersByTime(250)
+
+    await input.setValue('invalid date')
+    await input.trigger('keyup')
+
+    await document.activeElement.blur()
+    jest.advanceTimersByTime(250)
+
+    expect(input.element.value).toEqual('')
+    expect(wrapper.emitted('selected')).toBeFalsy()
+
+    // Valid date
+    await input.trigger('click')
+    jest.advanceTimersByTime(250)
+
+    await input.setValue('2 jan 22')
+    await input.trigger('keyup')
+
+    await document.activeElement.blur()
+    jest.advanceTimersByTime(250)
+
+    expect(input.element.value).toEqual('02 Jan 2022')
+    expect(wrapper.emitted('selected')).toBeTruthy()
+
+    // Unchanged date
+    await input.trigger('click')
+    jest.advanceTimersByTime(250)
+
+    await input.setValue('2 jan 22')
+    await input.trigger('keyup')
+
+    await document.activeElement.blur()
+    jest.advanceTimersByTime(250)
+
+    expect(input.element.value).toEqual('02 Jan 2022')
+    expect(wrapper.emitted('selected')).toHaveLength(1)
   })
 })

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -121,16 +121,12 @@ describe('DateInput', () => {
     )
   })
 
-  it('emits `close` when the calendar is open and enter is pressed', async () => {
-    await wrapper.setProps({
-      isOpen: true,
-    })
-
+  it('emits `select-typed-date` when enter is pressed', async () => {
     const input = wrapper.find('input')
 
     await input.trigger('keydown.enter')
 
-    expect(wrapper.emitted('close')).toBeTruthy()
+    expect(wrapper.emitted('select-typed-date')).toBeTruthy()
   })
 
   it("doesn't emit the date if typeable=false", async () => {
@@ -163,10 +159,10 @@ describe('Datepicker mount', () => {
     wrapper.destroy()
   })
 
-  it('sets the date on typedDate event', () => {
+  it('sets the date on `select-typed-date` event', () => {
     const today = new Date()
 
-    wrapper.vm.handleTypedDate(today)
+    wrapper.vm.selectTypedDate(today)
 
     expect(wrapper.vm.selectedDate).toEqual(today)
   })

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -167,6 +167,30 @@ describe('Datepicker mount', () => {
     expect(wrapper.vm.selectedDate).toEqual(today)
   })
 
+  it('emits `selected` when a valid date is typed and the `enter` key is pressed', async () => {
+    const input = wrapper.find('input')
+
+    input.setValue('Jan')
+    await input.trigger('keyup')
+
+    expect(wrapper.emitted('selected')).toBeUndefined()
+
+    await input.trigger('keydown.enter')
+
+    expect(wrapper.emitted('selected')).toBeDefined()
+    expect(wrapper.emitted('selected')[0][0]).toBeInstanceOf(Date)
+  })
+
+  it('does not emit `selected` when an invalid date is typed and the `enter` key is pressed', async () => {
+    const input = wrapper.find('input')
+
+    input.setValue('invalid date')
+    await input.trigger('keyup')
+    await input.trigger('keydown.enter')
+
+    expect(wrapper.emitted('selected')).toBeUndefined()
+  })
+
   it('shows the correct month as you type', async () => {
     const input = wrapper.find('input')
 

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -111,6 +111,21 @@ describe('DateInput', () => {
     expect(wrapper.emitted('select-typed-date')).toBeTruthy()
   })
 
+  it('parses a typed date using a function passed in via a prop', async () => {
+    await wrapper.setProps({
+      parser: (date) => {
+        return parse(date, 'yyyy/mm/dd', new Date())
+      },
+    })
+
+    const input = wrapper.find('input')
+
+    input.setValue('2022/01/05')
+    await input.trigger('blur')
+
+    expect(input.element.value).toBe('05 Jan 2022')
+  })
+
   it("doesn't emit the date if typeable=false", async () => {
     await wrapper.setProps({
       typeable: false,

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -1,5 +1,5 @@
 import { mount, shallowMount } from '@vue/test-utils'
-import { parse } from 'date-fns'
+import { format, parse } from 'date-fns'
 import DateInput from '~/components/DateInput.vue'
 import Datepicker from '~/components/Datepicker.vue'
 import { en } from '~/locale'
@@ -113,6 +113,9 @@ describe('DateInput', () => {
 
   it('parses a typed date using a function passed in via a prop', async () => {
     await wrapper.setProps({
+      format: (date) => {
+        return format(date, 'dd/mm/yyyy')
+      },
       parser: (date) => {
         return parse(date, 'yyyy/mm/dd', new Date())
       },
@@ -123,7 +126,7 @@ describe('DateInput', () => {
     input.setValue('2022/01/05')
     await input.trigger('blur')
 
-    expect(input.element.value).toBe('05 Jan 2022')
+    expect(input.element.value).toBe('05/01/2022')
   })
 
   it("doesn't emit the date if typeable=false", async () => {

--- a/test/unit/specs/DateUtils.spec.js
+++ b/test/unit/specs/DateUtils.spec.js
@@ -138,6 +138,12 @@ describe('dateUtils', () => {
     }).toThrowError('Parser needs to be a function')
   })
 
+  it('fails to parse because format is not a function when using a custom parser', () => {
+    expect(() => {
+      dateUtils.parseDate('16 April 2020', 'dd/MM/yyyy', en, () => {})
+    }).toThrowError('Format needs to be a function when using a custom parser')
+  })
+
   it('parses formats without day', () => {
     expect(dateUtils.parseDate('April 2020', 'MMMM yyyy')).toEqual(
       new Date('2020-04-01T00:00:00'),

--- a/test/unit/specs/DateUtils.spec.js
+++ b/test/unit/specs/DateUtils.spec.js
@@ -132,12 +132,10 @@ describe('dateUtils', () => {
     )
   })
 
-  it('fails to parse because of missing parser', () => {
+  it('fails to parse because parser is not a function', () => {
     expect(() => {
-      dateUtils.parseDate('16 April 2020', () => {})
-    }).toThrowError(
-      'Parser needs to be a function if you are using a custom formatter',
-    )
+      dateUtils.parseDate('16 April 2020', () => {}, en, 'dd/MM/yyyy')
+    }).toThrowError('Parser needs to be a function')
   })
 
   it('parses formats without day', () => {

--- a/test/unit/specs/DateUtils.spec.js
+++ b/test/unit/specs/DateUtils.spec.js
@@ -113,22 +113,22 @@ describe('dateUtils', () => {
 
   it('parses English dates', () => {
     expect(dateUtils.parseDate('16 April 2020', 'd MMMM yyyy')).toEqual(
-      '2020-04-16T00:00:00',
+      new Date('2020-04-16T00:00:00'),
     )
     expect(dateUtils.parseDate('16th Nov 2020', 'do MMM yyyy')).toEqual(
-      '2020-11-16T00:00:00',
+      new Date('2020-11-16T00:00:00'),
     )
     expect(dateUtils.parseDate('16th November 2020', 'do MMMM yyyy')).toEqual(
-      '2020-11-16T00:00:00',
+      new Date('2020-11-16T00:00:00'),
     )
     expect(dateUtils.parseDate('Thu 16th Apr 2020', 'E do MMM yyyy')).toEqual(
-      '2020-04-16T00:00:00',
+      new Date('2020-04-16T00:00:00'),
     )
     expect(dateUtils.parseDate('16.04.2020', 'dd.MM.yyyy')).toEqual(
-      '2020-04-16T00:00:00',
+      new Date('2020-04-16T00:00:00'),
     )
     expect(dateUtils.parseDate('04.16.2020', 'MM.dd.yyyy')).toEqual(
-      '2020-04-16T00:00:00',
+      new Date('2020-04-16T00:00:00'),
     )
   })
 
@@ -142,20 +142,20 @@ describe('dateUtils', () => {
 
   it('parses formats without day', () => {
     expect(dateUtils.parseDate('April 2020', 'MMMM yyyy')).toEqual(
-      '2020-04-01T00:00:00',
+      new Date('2020-04-01T00:00:00'),
     )
   })
 
   it('parses formats without month', () => {
     expect(dateUtils.parseDate('15 2020', 'dd yyyy')).toEqual(
-      '2020-01-15T00:00:00',
+      new Date('2020-01-15T00:00:00'),
     )
   })
 
   it('parses formats without year', () => {
     const currentYear = new Date().getFullYear()
     expect(dateUtils.parseDate('15 April', 'dd MMMM')).toEqual(
-      `${currentYear}-04-15T00:00:00`,
+      new Date(`${currentYear}-04-15T00:00:00`),
     )
   })
 


### PR DESCRIPTION
This fixes #133 and #142.

I've created a new data variable called `latestValidTypedDate` in `Datepicker.vue`. This is initially set to the computed open date and is updated each time a valid typed date is entered in the input field, or when a new date is selected.

This means that a typeable datepicker no longer emits a `selected` event each time the typed date changes, but only when:
- a date is selected via any of the standard (non-typeable) methods i.e. mouse click on a cell, pressing enter/spacebar on a focused cell
- a new valid date is typed in the input field and the enter key is pressed
- a new valid date is typed in the input field and the datepicker loses focus

The `input` event, on the other hand, is emitted *each time a valid date is typed* - in addition to those occasions when a new date is entered via a standard (non-typeable) method.

===
PS. Sorry this took so long - I've been helping my mum move into 'sheltered accommodation' which has taken up a lot of my time. All done now, thankfully - and she's very happy to be there!