### PR TITLE
Typeable datepicker with v-model: only fire input event when selected (amended)

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -429,7 +429,6 @@ export default {
       this.close()
 
       this.$emit('selected', null)
-      this.$emit('input', null)
       this.$emit('cleared')
     },
     /**
@@ -542,7 +541,6 @@ export default {
         this.latestValidTypedDate,
       )
       this.setPageDate(date)
-      this.$emit('input', date)
 
       if (this.isPageChange(originalPageDate)) {
         this.handlePageChange({
@@ -606,7 +604,6 @@ export default {
 
         if (isDateDisabled) {
           parsedValue = null
-          this.$emit('input', parsedValue)
         }
         this.setValue(parsedValue)
       } else if (this.typeable) {
@@ -692,7 +689,6 @@ export default {
 
       this.setValue(date)
       this.$emit('selected', date)
-      this.$emit('input', date)
     },
     /**
      * Select the date from a 'select-typed-date' event
@@ -784,8 +780,9 @@ export default {
      * @param {Date|String|Number|null} date
      */
     setValue(date) {
-      this.selectedDate = date || null
+      this.selectedDate = date
       this.setPageDate(date)
+      this.$emit('input', date)
 
       if (this.typeable) {
         this.latestValidTypedDate = date || this.computedOpenDate

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -424,10 +424,9 @@ export default {
         return
       }
 
-      this.selectedDate = null
+      this.setValue(null)
       this.focus.refs = ['input']
       this.close()
-      this.setPageDate()
 
       this.$emit('selected', null)
       this.$emit('input', null)

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -427,8 +427,6 @@ export default {
       this.setValue(null)
       this.focus.refs = ['input']
       this.close()
-
-      this.$emit('selected', null)
       this.$emit('cleared')
     },
     /**
@@ -688,7 +686,6 @@ export default {
       const date = new Date(timestamp)
 
       this.setValue(date)
-      this.$emit('selected', date)
     },
     /**
      * Select the date from a 'select-typed-date' event
@@ -697,7 +694,6 @@ export default {
     selectTypedDate(date) {
       this.setValue(date)
       this.reviewFocus()
-      this.$emit('selected', date)
 
       if (this.isOpen) {
         this.close()
@@ -772,17 +768,17 @@ export default {
 
       if (hasChanged()) {
         this.setValue(date)
-        this.$emit('selected', date)
       }
     },
     /**
      * Set the datepicker value (and, if typeable, update `latestValidTypedDate`)
-     * @param {Date|String|Number|null} date
+     * @param {Date|null} date
      */
     setValue(date) {
       this.selectedDate = date
       this.setPageDate(date)
       this.$emit('input', date)
+      this.$emit('selected', date)
 
       if (this.typeable) {
         this.latestValidTypedDate = date || this.computedOpenDate


### PR DESCRIPTION
As discussed in #151, currently `input` and `selected` events do the same thing (as you can see from these 3 commits)...

Going forward, I think we should just emit an `input` event, so that instead of writing:

```html
<input type="date" />
<input type="date" value="someDate" oninput="doSomething" />
```

... users can write:

```vue
<Datepicker v-model="someDate" />
<Datepicker :value="someDate" @input="doSomething" />
```

As previously mentioned, I think we should also get rid of  `selectedDate` internally and use `value` instead.
