### PR TITLE
Disable video capture when running Cypress tests via the command line

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -10,10 +10,11 @@ module.exports = defineConfig({
       return {
         ...config,
         fixturesFolder: 'test/e2e/fixtures',
-        specPattern: 'test/e2e/specs/**/*.{feature,features}',
         screenshotsFolder: 'test/e2e/screenshots',
-        videosFolder: 'test/e2e/videos',
+        specPattern: 'test/e2e/specs/**/*.{feature,features}',
         supportFile: 'test/e2e/support/index.js',
+        video: false,
+        videosFolder: 'test/e2e/videos',
       }
     },
     baseUrl: 'http://localhost:8080',


### PR DESCRIPTION
With Cypress 10, when you run `npm run test:e2e` you can no longer play through ALL the tests (visually) at the same time, so I've found it useful to run the e2e tests via the command line with `npm run test:e2e:ci`. But, we don't need to wait for the videos to be generated, hence this commit.

N.B. We might like to add to the above command line to the CI pipeline at some point?