### PR TITLE
Update deprecated slot syntax

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,6 +88,8 @@ module.exports = {
       'PascalCase',
       { registeredComponentsOnly: false },
     ],
+    'vue/html-self-closing': 'off',
+    'vue/max-attributes-per-line': 'off',
     'vue/no-deprecated-scope-attribute': 'error',
     'arrow-body-style': 'off',
   },

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -10,10 +10,11 @@ module.exports = defineConfig({
       return {
         ...config,
         fixturesFolder: 'test/e2e/fixtures',
-        specPattern: 'test/e2e/specs/**/*.{feature,features}',
         screenshotsFolder: 'test/e2e/screenshots',
-        videosFolder: 'test/e2e/videos',
+        specPattern: 'test/e2e/specs/**/*.{feature,features}',
         supportFile: 'test/e2e/support/index.js',
+        video: false,
+        videosFolder: 'test/e2e/videos',
       }
     },
     baseUrl: 'http://localhost:8080',

--- a/docs/guide/Slots/README.md
+++ b/docs/guide/Slots/README.md
@@ -1,6 +1,18 @@
 # Slots
 
-Slots will help you customize content.
+Slots will help you customize content.<br>
+
+N.B. If your slot content contains any links, you'll need to add `tabindex="0"` to your `a` tags in order for the links to be tabbable:
+```html
+<DatePicker>
+  <template #beforeCalendarHeaderDay>
+    <div>
+      You must add tabindex="0" to <a href="#" tabindex="0">this link</a>
+      so that users can tab to it.
+    </div>
+  </template>
+</DatePicker>
+```
 
 ## beforeCalendarHeader
 

--- a/example/Demo.vue
+++ b/example/Demo.vue
@@ -37,6 +37,55 @@
     </div>
 
     <div class="example">
+      <h3>Datepicker with slots</h3>
+      <Datepicker placeholder="Select Date">
+        <template #beforeCalendarHeader>
+          <div class="slot">
+            Read all about:
+            <a
+              href="https://sumcumo.github.io/vue-datepicker/guide/Slots/"
+              tabindex="0"
+              target="_blank"
+            >
+              available slots
+            </a>
+          </div>
+        </template>
+
+        <template #calendarFooter>
+          <div class="slot">
+            They're very flexible. Here's that link again:
+            <a
+              href="https://sumcumo.github.io/vue-datepicker/guide/Slots/"
+              tabindex="0"
+              target="_blank"
+            >
+              available slots
+            </a>
+          </div>
+        </template>
+      </Datepicker>
+      <pre>
+&lt;datepicker placeholder="Select Date"&gt;
+  &lt;template #beforeCalendarHeader&gt;
+    &lt;div&gt;
+      Read all about: &lt;a href="https://sumcumo.github.io/vue-datepicker/guide/Slots/"
+      tabindex="0"&gt;available slots&lt;/a&gt;
+    &lt;/div&gt;
+  &lt;/template&gt;
+
+  &lt;template #calendarFooter&gt;
+    &lt;div&gt;
+      They're very flexible. Here's that link again:
+      &lt;a href="https://sumcumo.github.io/vue-datepicker/guide/Slots/"
+      tabindex="0"&gt;available slots&lt;/a&gt;
+    &lt;/div&gt;
+  &lt;/template&gt;
+&lt;/datepicker&gt;</pre
+      >
+    </div>
+
+    <div class="example">
       <h3>Bootstrap styled datepicker</h3>
       <Datepicker
         :bootstrap-styling="true"
@@ -50,10 +99,7 @@
 
     <div class="example">
       <h3>v-model datepicker</h3>
-      <Datepicker
-        v-model="vModelExample"
-        placeholder="Select Date"
-      />
+      <Datepicker v-model="vModelExample" placeholder="Select Date" />
       <code>
         &lt;datepicker placeholder="Select Date"
         v-model="vmodelexample"&gt;&lt;/datepicker&gt;
@@ -72,17 +118,21 @@
 
     <div class="example">
       <h3>Format datepicker</h3>
-      <Datepicker :format="format"/>
+      <Datepicker :format="format" />
       <code>&lt;datepicker format="format"&gt;&lt;/datepicker&gt;</code>
       <div class="settings">
         <h5>Settings</h5>
         <div class="form-group">
           <label>Format</label>
           <select v-model="format">
-            <option value="MMMM d, yyyy">MMMM d, yyyy e.g. February 6, 2022</option>
+            <option value="MMMM d, yyyy">
+              MMMM d, yyyy e.g. February 6, 2022
+            </option>
             <option value="do MMM yyyy">do MMM yyyy e.g. 6th Feb 2022</option>
             <option value="yyyy-MM-dd">yyyy-MM-dd e.g. 2022-02-06</option>
-            <option value="E do MMM yyyy">E do MMM yyyy e.g. Sun 6th Feb 2022</option>
+            <option value="E do MMM yyyy">
+              E do MMM yyyy e.g. Sun 6th Feb 2022
+            </option>
             <option value="dd/MM/yy">dd/MM/yy e.g. 06/02/22</option>
             <option value="dd.MM.yyyy">dd.MM.yyyy e.g. 06.02.2022</option>
             <option value="M/d/yyyy">M/d/yyyy e.g. 2/6/2022</option>
@@ -93,10 +143,7 @@
 
     <div class="example">
       <h3>Format a date with the date-fns library</h3>
-      <Datepicker
-        :format="customFormatter"
-        v-model="state"
-      />
+      <Datepicker :format="customFormatter" v-model="state" />
       <code>
         &lt;datepicker :format="customFormatter"&gt;&lt;/datepicker&gt;
       </code>
@@ -106,11 +153,17 @@
           <label>Format</label>
           <select v-model="formatDateFns">
             <option value="qqq yyyy">qqq yyyy e.g. Q1 2022</option>
-            <option value="EEEE do MMMM yyyy">EEEE do MMMM yyyy e.g. Sunday 6th February 2022</option>
-            <option value="MMMM d, yyyy">MMMM d, yyyy e.g. February 6, 2022</option>
+            <option value="EEEE do MMMM yyyy">
+              EEEE do MMMM yyyy e.g. Sunday 6th February 2022
+            </option>
+            <option value="MMMM d, yyyy">
+              MMMM d, yyyy e.g. February 6, 2022
+            </option>
             <option value="do MMM yyyy">do MMM yyyy e.g. 6th Feb 2022</option>
             <option value="yyyy-MM-dd">yyyy-MM-dd e.g. 2022-02-06</option>
-            <option value="E do MMM yyyy">E do MMM yyyy e.g. Sun 6th Feb 2022</option>
+            <option value="E do MMM yyyy">
+              E do MMM yyyy e.g. Sun 6th Feb 2022
+            </option>
             <option value="dd/MM/yy">dd/MM/yy e.g. 06/02/22</option>
             <option value="dd.MM.yyyy">dd.MM.yyyy e.g. 06.02.2022</option>
             <option value="M/d/yyyy">M/d/yyyy e.g. 2/6/2022</option>
@@ -546,8 +599,20 @@ select {
   margin-bottom: 2em;
 }
 
+.slot {
+  background-color: #cae5ed;
+  padding: 0.5em;
+}
+
+.slot > a {
+  color: #176982;
+  padding: 0.1em;
+  border-radius: 0.1em;
+}
+
 code,
 pre {
+  color: #e83e8c;
   margin: 1em 0;
   padding: 1em;
   border: 1px solid #bbb;

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -47,10 +47,21 @@
       @set-focus="setFocus($event)"
       @typed-date="handleTypedDate"
     >
-      <slot slot="beforeDateInput" name="beforeDateInput" />
-      <slot slot="afterDateInput" name="afterDateInput" />
-      <slot slot="clearBtn" name="clearBtn" />
-      <slot slot="calendarBtn" name="calendarBtn" />
+      <template #beforeDateInput>
+        <slot name="beforeDateInput" />
+      </template>
+
+      <template #afterDateInput>
+        <slot name="afterDateInput" />
+      </template>
+
+      <template #clearBtn>
+        <slot name="clearBtn" />
+      </template>
+
+      <template #calendarBtn>
+        <slot name="calendarBtn" />
+      </template>
     </DateInput>
 
     <Popup
@@ -111,8 +122,8 @@
                 @set-transition-name="setTransitionName($event)"
                 @set-view="setView"
               >
-                <template v-for="slotKey of calendarSlots">
-                  <slot :slot="slotKey" :name="slotKey" />
+                <template v-for="slotKey of calendarSlots" #[slotKey]>
+                  <slot :name="slotKey" />
                 </template>
                 <template #dayCellContent="{ cell }">
                   <slot v-if="cell" name="dayCellContent" :cell="cell" />

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -15,7 +15,9 @@
       @page-change="changePage($event)"
       @set-focus="$emit('set-focus', $event)"
     >
-      <slot slot="prevIntervalBtn" name="prevIntervalBtn" />
+      <template #prevIntervalBtn>
+        <slot name="prevIntervalBtn" />
+      </template>
       <UpButton
         ref="up"
         :class="{ btn: bootstrapStyling }"
@@ -27,7 +29,9 @@
       >
         {{ pageTitleDay }}
       </UpButton>
-      <slot slot="nextIntervalBtn" name="nextIntervalBtn" />
+      <template #nextIntervalBtn>
+        <slot name="nextIntervalBtn" />
+      </template>
     </PickerHeader>
 
     <div>

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -15,7 +15,9 @@
       @page-change="changePage($event)"
       @set-focus="$emit('set-focus', $event)"
     >
-      <slot slot="prevIntervalBtn" name="prevIntervalBtn" />
+      <template #prevIntervalBtn>
+        <slot name="prevIntervalBtn" />
+      </template>
       <UpButton
         ref="up"
         :class="{ btn: bootstrapStyling }"
@@ -27,7 +29,9 @@
       >
         {{ pageTitleMonth }}
       </UpButton>
-      <slot slot="nextIntervalBtn" name="nextIntervalBtn" />
+      <template #nextIntervalBtn>
+        <slot name="nextIntervalBtn" />
+      </template>
     </PickerHeader>
 
     <div class="cells-wrapper">

--- a/src/components/PickerYear.vue
+++ b/src/components/PickerYear.vue
@@ -15,7 +15,9 @@
       @page-change="changePage($event)"
       @set-focus="$emit('set-focus', $event)"
     >
-      <slot slot="prevIntervalBtn" name="prevIntervalBtn" />
+      <template #prevIntervalBtn>
+        <slot name="prevIntervalBtn" />
+      </template>
       <UpButton
         ref="up"
         :class="{ btn: bootstrapStyling }"
@@ -24,7 +26,9 @@
       >
         {{ pageTitleYear }}
       </UpButton>
-      <slot slot="nextIntervalBtn" name="nextIntervalBtn" />
+      <template #nextIntervalBtn>
+        <slot name="nextIntervalBtn" />
+      </template>
     </PickerHeader>
 
     <div class="cells-wrapper">

--- a/src/mixins/navMixin.vue
+++ b/src/mixins/navMixin.vue
@@ -227,6 +227,10 @@ export default {
      * @returns {Array}
      */
     getFocusableElements(fragment) {
+      if (!fragment) {
+        return []
+      }
+
       const navNodeList = fragment.querySelectorAll(
         'button:enabled, [href], input:not([type=hidden]), select:enabled, textarea:enabled, [tabindex]:not([tabindex="-1"])',
       )


### PR DESCRIPTION
@MrWook - I know you've already done this as part of your 'feat/vue3-support' branch, but it should also be included in the vue 2 version. 

Following this change, some of the `shallowMount` tests in Datepicker.spec.js were failing because they were passing undefined html fragments to the `getFocusableElements` method in navMixin.vue. This occurred on a view change (which fires `reviewFocus` and then `setNavElements` on nextTick. 

I decided to tweak the `getFocusableElements` method slightly to return an empty array when the html fragment is undefined. Let me know if that's OK? The alternative would be to move those tests to the `mount` block.