### PR TITLE
Use local timezone in e2e tests

### DIFF
--- a/test/e2e/specs/CellNavigation/index.js
+++ b/test/e2e/specs/CellNavigation/index.js
@@ -65,18 +65,11 @@ describe('Focusable Cell', () => {
       'the calendar is open on {string} with view {string} and disabled dates {string} {string}',
       // eslint-disable-next-line max-params
       (openDate, view, toOrFrom, disabled) => {
-        const disabledDates =
-          toOrFrom === 'to'
-            ? {
-                to: new Date(disabled),
-              }
-            : {
-                from: new Date(disabled),
-              }
-
         createCalendar({
           openDate,
-          disabledDates,
+          disabledDates: {
+            [toOrFrom]: new Date(disabled),
+          },
           initialView: view,
         })
 

--- a/test/e2e/specs/CellNavigation/index.js
+++ b/test/e2e/specs/CellNavigation/index.js
@@ -2,7 +2,13 @@ import { Given, When, Then, And } from 'cypress-cucumber-preprocessor/steps'
 
 const { createCalendar, clickThe, the, theFirst } = cy
 
-describe('Focusable Cell', () => {
+function localTimeZone(dateStr) {
+  const parts = dateStr.split('-')
+
+  return new Date(parts[0], parts[1] - 1, parts[2])
+}
+
+describe('Cell Navigation', () => {
   describe('@id-1: Arrow {string} (isRtl: {string})', () => {
     Given(
       'the calendar is open on {string} and isRtl is {string}',
@@ -66,9 +72,9 @@ describe('Focusable Cell', () => {
       // eslint-disable-next-line max-params
       (openDate, view, toOrFrom, disabled) => {
         createCalendar({
-          openDate,
+          openDate: localTimeZone(openDate),
           disabledDates: {
-            [toOrFrom]: new Date(disabled),
+            [toOrFrom]: localTimeZone(disabled),
           },
           initialView: view,
         })

--- a/test/e2e/specs/TypeableCalendar/index.js
+++ b/test/e2e/specs/TypeableCalendar/index.js
@@ -2,120 +2,122 @@ import { Given, When, Then, And } from 'cypress-cucumber-preprocessor/steps'
 
 const { createCalendar, clickThe, focusThe, the } = cy
 
-describe('@id-1: Press the enter key', () => {
-  Given(
-    'the typeable calendar is {string} and a {string} date is typed',
-    (openOrClosed, validity) => {
-      const date = validity === 'valid' ? '1 March 2021' : 'invalid date'
-      const isNot = openOrClosed === 'closed' ? 'not.' : ''
+describe('Typeable calendar', () => {
+  describe('@id-1: Press the enter key', () => {
+    Given(
+      'the typeable calendar is {string} and a {string} date is typed',
+      (openOrClosed, validity) => {
+        const date = validity === 'valid' ? '1 March 2021' : 'invalid date'
+        const isNot = openOrClosed === 'closed' ? 'not.' : ''
 
-      createCalendar({
-        typeable: true,
-      })
+        createCalendar({
+          typeable: true,
+        })
 
-      if (openOrClosed === 'open') {
-        clickThe('input')
-      }
+        if (openOrClosed === 'open') {
+          clickThe('input')
+        }
 
-      focusThe('input').type(date)
+        focusThe('input').type(date)
 
-      the('calendar').should(`${isNot}be.visible`)
-    },
-  )
+        the('calendar').should(`${isNot}be.visible`)
+      },
+    )
 
-  When('the user presses the enter key', () => {
-    // Until Cypress supports native events, we can simulate this by blurring the input first
-    the('input').blur().type('{enter}')
-  })
+    When('the user presses the enter key', () => {
+      // Until Cypress supports native events, we can simulate this by blurring the input first
+      the('input').blur().type('{enter}')
+    })
 
-  Then('the calendar {string}', (opensOrCloses) => {
-    const isNot = opensOrCloses === 'closes' ? 'not.' : ''
-
-    the('calendar').should(`${isNot}be.visible`)
-  })
-
-  And('the date is {string}', (formattedOrCleared) => {
-    const value = formattedOrCleared === 'formatted' ? '01 Mar 2021' : ''
-
-    the('input').should('have.value', value)
-  })
-
-  And('the input has focus', () => {
-    the('input').should('have.focus')
-  })
-})
-
-describe('@id-2: Press the down arrow', () => {
-  Given(
-    'the typeable calendar is {string} and a {string} date is typed',
-    (openOrClosed, validity) => {
-      const date = validity === 'valid' ? '1 March 2021' : 'invalid date'
-      const isNot = openOrClosed === 'closed' ? 'not.' : ''
-
-      createCalendar({
-        typeable: true,
-      })
-
-      if (openOrClosed === 'open') {
-        clickThe('input')
-      }
-
-      focusThe('input').type(date)
+    Then('the calendar {string}', (opensOrCloses) => {
+      const isNot = opensOrCloses === 'closes' ? 'not.' : ''
 
       the('calendar').should(`${isNot}be.visible`)
-    },
-  )
+    })
 
-  When('the user presses the `down` arrow', () => {
-    focusThe('input').type(`{downArrow}`)
+    And('the date is {string}', (formattedOrCleared) => {
+      const value = formattedOrCleared === 'formatted' ? '01 Mar 2021' : ''
+
+      the('input').should('have.value', value)
+    })
+
+    And('the input has focus', () => {
+      the('input').should('have.focus')
+    })
   })
 
-  Then('the calendar {string}', (opensOrCloses) => {
-    const isNot = opensOrCloses === 'closes' ? 'not.' : ''
+  describe('@id-2: Press the down arrow', () => {
+    Given(
+      'the typeable calendar is {string} and a {string} date is typed',
+      (openOrClosed, validity) => {
+        const date = validity === 'valid' ? '1 March 2021' : 'invalid date'
+        const isNot = openOrClosed === 'closed' ? 'not.' : ''
 
-    the('calendar').should(`${isNot}be.visible`)
-  })
+        createCalendar({
+          typeable: true,
+        })
 
-  And('the date is {string}', (formattedOrCleared) => {
-    const value = formattedOrCleared === 'formatted' ? '01 Mar 2021' : ''
+        if (openOrClosed === 'open') {
+          clickThe('input')
+        }
 
-    the('input').should('have.value', value)
-  })
+        focusThe('input').type(date)
 
-  And('the previous button has focus', () => {
-    the('previous-button').should('have.focus')
-  })
-})
+        the('calendar').should(`${isNot}be.visible`)
+      },
+    )
 
-describe('@id-3: Press the down arrow (no header)', () => {
-  Given(
-    'the typeable calendar with no header is {string} and a {string} date is typed',
-    (openOrClosed, validity) => {
-      const date = validity === 'valid' ? '1 March 2021' : 'invalid date'
-      const isNot = openOrClosed === 'closed' ? 'not.' : ''
+    When('the user presses the `down` arrow', () => {
+      focusThe('input').type(`{downArrow}`)
+    })
 
-      createCalendar({
-        showHeader: false,
-        typeable: true,
-      })
-
-      if (openOrClosed === 'open') {
-        clickThe('input')
-      }
-
-      focusThe('input').type(date)
+    Then('the calendar {string}', (opensOrCloses) => {
+      const isNot = opensOrCloses === 'closes' ? 'not.' : ''
 
       the('calendar').should(`${isNot}be.visible`)
-    },
-  )
+    })
 
-  When('the user presses the `down` arrow')
+    And('the date is {string}', (formattedOrCleared) => {
+      const value = formattedOrCleared === 'formatted' ? '01 Mar 2021' : ''
 
-  Then('the calendar {string}')
+      the('input').should('have.value', value)
+    })
 
-  And('the date is {string}')
+    And('the previous button has focus', () => {
+      the('previous-button').should('have.focus')
+    })
+  })
 
-  And('the tabbable cell has focus', () => {
-    the('tabbable-cell').should('have.focus')
+  describe('@id-3: Press the down arrow (no header)', () => {
+    Given(
+      'the typeable calendar with no header is {string} and a {string} date is typed',
+      (openOrClosed, validity) => {
+        const date = validity === 'valid' ? '1 March 2021' : 'invalid date'
+        const isNot = openOrClosed === 'closed' ? 'not.' : ''
+
+        createCalendar({
+          showHeader: false,
+          typeable: true,
+        })
+
+        if (openOrClosed === 'open') {
+          clickThe('input')
+        }
+
+        focusThe('input').type(date)
+
+        the('calendar').should(`${isNot}be.visible`)
+      },
+    )
+
+    When('the user presses the `down` arrow')
+
+    Then('the calendar {string}')
+
+    And('the date is {string}')
+
+    And('the tabbable cell has focus', () => {
+      the('tabbable-cell').should('have.focus')
+    })
   })
 })

--- a/test/unit/specs/DateInput/DateInput.spec.js
+++ b/test/unit/specs/DateInput/DateInput.spec.js
@@ -14,12 +14,7 @@ describe('DateInput shallowMounted', () => {
   let wrapper
 
   beforeEach(() => {
-    wrapper = shallowMount(DateInput, {
-      propsData: {
-        selectedDate: new Date(2018, 2, 24),
-        translation: en,
-      },
-    })
+    wrapper = shallowMount(DateInput)
   })
 
   afterEach(() => {
@@ -31,13 +26,42 @@ describe('DateInput shallowMounted', () => {
   })
 
   it('clears the date', async () => {
-    await wrapper.setProps({
-      selectedDate: null,
-    })
-
     const input = wrapper.find('input')
 
     expect(input.element.value).toEqual('')
+  })
+
+  it('emits `open` event on click', async () => {
+    const input = wrapper.find('input')
+    await input.trigger('click')
+
+    expect(wrapper.emitted('open')).toBeTruthy()
+  })
+
+  it('emits `open` event when the space bar is pressed on the input field', async () => {
+    const input = wrapper.find('input')
+
+    await input.trigger('keydown.space')
+    await input.trigger('keyup.space')
+
+    expect(wrapper.emitted('open')).toBeTruthy()
+  })
+})
+
+describe('DateInput shallowMounted with selectedDate', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = shallowMount(DateInput, {
+      propsData: {
+        selectedDate: new Date(2018, 2, 24),
+        translation: en,
+      },
+    })
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
   })
 
   it('formats date', () => {
@@ -176,22 +200,6 @@ describe('DateInput shallowMounted', () => {
     await input.trigger('keydown.esc')
 
     expect(wrapper.emitted('close')).toBeTruthy()
-  })
-
-  it('emits `open` event on click', async () => {
-    const input = wrapper.find('input')
-    await input.trigger('click')
-
-    expect(wrapper.emitted('open')).toBeTruthy()
-  })
-
-  it('emits `open` event when the space bar is pressed on the input field', async () => {
-    const input = wrapper.find('input')
-
-    await input.trigger('keydown.space')
-    await input.trigger('keyup.space')
-
-    expect(wrapper.emitted('open')).toBeTruthy()
   })
 
   it('emits `open` event on focus when `showCalendarOnFocus` is true', async () => {

--- a/test/unit/specs/DateInput/DateInput.spec.js
+++ b/test/unit/specs/DateInput/DateInput.spec.js
@@ -46,6 +46,14 @@ describe('DateInput shallowMounted', () => {
 
     expect(wrapper.emitted('open')).toBeTruthy()
   })
+
+  it('does not emit `open` event on focus', async () => {
+    const input = wrapper.find('input')
+
+    await input.trigger('focus')
+
+    expect(wrapper.emitted('open')).toBeFalsy()
+  })
 })
 
 describe('DateInput shallowMounted with selectedDate', () => {
@@ -81,64 +89,6 @@ describe('DateInput shallowMounted with selectedDate', () => {
     const input = wrapper.find('input')
 
     expect(input.element.value).toEqual('15.01.2016')
-  })
-
-  it('emits `open` event on focus when `show-calendar-on-focus` is true', async () => {
-    await wrapper.setProps({
-      showCalendarOnFocus: true,
-    })
-
-    const input = wrapper.find('input')
-
-    await input.trigger('focus')
-
-    expect(wrapper.emitted('open')).toBeTruthy()
-  })
-
-  it('does not emit `open` event on focus when show-calendar-on-focus prop is false', async () => {
-    await wrapper.setProps({
-      showCalendarOnFocus: false,
-    })
-
-    const input = wrapper.find('input')
-
-    await input.trigger('focus')
-
-    expect(wrapper.emitted('open')).toBeFalsy()
-  })
-
-  it('closes calendar via button and reopens via focus when `show-calendar-on-focus` is true', async () => {
-    await wrapper.setProps({
-      calendarButton: true,
-      showCalendarOnFocus: true,
-    })
-
-    const input = wrapper.find('input')
-    const calendarButton = wrapper.find('button[data-test-calendar-button]')
-
-    await input.trigger('focus')
-    expect(wrapper.emitted('open')).toBeTruthy()
-
-    await input.trigger('blur')
-    await calendarButton.trigger('focus')
-    await calendarButton.trigger('click')
-    expect(wrapper.emitted('close')).toBeFalsy()
-
-    await input.trigger('focus')
-    expect(wrapper.emitted('open')).toBeTruthy()
-  })
-
-  it('opens calendar on click when `show-calendar-on-focus` is true', async () => {
-    await wrapper.setProps({
-      showCalendarOnFocus: true,
-    })
-
-    const input = wrapper.find('input')
-
-    await input.trigger('focus')
-    await input.trigger('click')
-
-    expect(wrapper.emitted('open')).toBeTruthy()
   })
 
   it('adds bootstrap classes', async () => {
@@ -202,20 +152,6 @@ describe('DateInput shallowMounted with selectedDate', () => {
     expect(wrapper.emitted('close')).toBeTruthy()
   })
 
-  it('emits `open` event on focus when `showCalendarOnFocus` is true', async () => {
-    const input = wrapper.find('input')
-    await input.trigger('focus')
-
-    expect(wrapper.emitted('open')).toBeFalsy()
-
-    await wrapper.setProps({
-      showCalendarOnFocus: true,
-    })
-    await input.trigger('focus')
-
-    expect(wrapper.emitted('open')).toBeTruthy()
-  })
-
   it('opens ONLY on button click when the relevant prop is set', async () => {
     await wrapper.setProps({
       calendarButton: true,
@@ -247,5 +183,58 @@ describe('DateInput shallowMounted with selectedDate', () => {
     await input.trigger('keydown.backspace')
 
     expect(wrapper.emitted('clear-date')).toBeTruthy()
+  })
+})
+
+describe('DateInput shallowMounted with showCalendarOnFocus', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = shallowMount(DateInput, {
+      propsData: {
+        showCalendarOnFocus: true,
+      },
+    })
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  it('emits `open` event on focus', async () => {
+    const input = wrapper.find('input')
+
+    await input.trigger('focus')
+
+    expect(wrapper.emitted('open')).toBeTruthy()
+  })
+
+  it('opens calendar on click when `show-calendar-on-focus` is true', async () => {
+    const input = wrapper.find('input')
+
+    await input.trigger('focus')
+    await input.trigger('click')
+
+    expect(wrapper.emitted('open')).toBeTruthy()
+  })
+
+  it('closes calendar via button and reopens via focus', async () => {
+    await wrapper.setProps({
+      calendarButton: true,
+    })
+
+    const input = wrapper.find('input')
+    const calendarButton = wrapper.find('button[data-test-calendar-button]')
+
+    await input.trigger('focus')
+    expect(wrapper.emitted('open')).toBeTruthy()
+
+    await input.trigger('blur')
+    await calendarButton.trigger('focus')
+    await calendarButton.trigger('click')
+    expect(wrapper.emitted('close')).toBeFalsy()
+
+    await input.trigger('focus')
+    expect(wrapper.emitted('open')).toBeTruthy()
   })
 })

--- a/test/unit/specs/DateInput/DateInput.spec.js
+++ b/test/unit/specs/DateInput/DateInput.spec.js
@@ -54,6 +54,44 @@ describe('DateInput shallowMounted', () => {
 
     expect(wrapper.emitted('open')).toBeFalsy()
   })
+
+  it('can be disabled', async () => {
+    await wrapper.setProps({
+      disabled: true,
+    })
+
+    const input = wrapper.find('input')
+
+    expect(input.attributes().disabled).toBeDefined()
+  })
+
+  it('emits `close` when escape is pressed and calendar is open', async () => {
+    await wrapper.setProps({
+      isOpen: true,
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('keydown.esc')
+
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('opens ONLY on button click when showCalendarOnButtonClick prop is set', async () => {
+    await wrapper.setProps({
+      calendarButton: true,
+      showCalendarOnButtonClick: true,
+    })
+
+    const input = wrapper.find('input')
+    await input.trigger('click')
+
+    expect(wrapper.emitted('open')).toBeFalsy()
+
+    const calendarButton = wrapper.find('button[data-test-calendar-button]')
+    await calendarButton.trigger('click')
+
+    expect(wrapper.emitted('open')).toBeTruthy()
+  })
 })
 
 describe('DateInput shallowMounted with selectedDate', () => {
@@ -80,7 +118,6 @@ describe('DateInput shallowMounted with selectedDate', () => {
 
   it('delegates date formatting', async () => {
     await wrapper.setProps({
-      selectedDate: new Date(2016, 0, 15),
       format: (date) => {
         return format(new Date(date), 'dd.MM.yyyy')
       },
@@ -88,17 +125,7 @@ describe('DateInput shallowMounted with selectedDate', () => {
 
     const input = wrapper.find('input')
 
-    expect(input.element.value).toEqual('15.01.2016')
-  })
-
-  it('can be disabled', async () => {
-    await wrapper.setProps({
-      disabled: true,
-    })
-
-    const input = wrapper.find('input')
-
-    expect(input.attributes().disabled).toBeDefined()
+    expect(input.element.value).toEqual('24.03.2018')
   })
 
   it('accepts a function as a formatter', async () => {
@@ -109,34 +136,6 @@ describe('DateInput shallowMounted with selectedDate', () => {
     const input = wrapper.find('input')
 
     expect(input.element.value).toEqual('!')
-  })
-
-  it('emits `close` when escape is pressed and calendar is open', async () => {
-    await wrapper.setProps({
-      isOpen: true,
-    })
-
-    const input = wrapper.find('input')
-    await input.trigger('keydown.esc')
-
-    expect(wrapper.emitted('close')).toBeTruthy()
-  })
-
-  it('opens ONLY on button click when the relevant prop is set', async () => {
-    await wrapper.setProps({
-      calendarButton: true,
-      showCalendarOnButtonClick: true,
-    })
-
-    const input = wrapper.find('input')
-    await input.trigger('click')
-
-    expect(wrapper.emitted('open')).toBeFalsy()
-
-    const calendarButton = wrapper.find('button[data-test-calendar-button]')
-    await calendarButton.trigger('click')
-
-    expect(wrapper.emitted('open')).toBeTruthy()
   })
 
   it('emits `clear-date` when delete is pressed', async () => {

--- a/test/unit/specs/DateInput/DateInput.spec.js
+++ b/test/unit/specs/DateInput/DateInput.spec.js
@@ -91,36 +91,6 @@ describe('DateInput shallowMounted with selectedDate', () => {
     expect(input.element.value).toEqual('15.01.2016')
   })
 
-  it('adds bootstrap classes', async () => {
-    await wrapper.setProps({
-      bootstrapStyling: true,
-    })
-
-    const input = wrapper.find('input')
-
-    expect(input.element.classList).toContain('form-control')
-  })
-
-  it('appends bootstrap classes', async () => {
-    await wrapper.setProps({
-      inputClass: 'someClass',
-      bootstrapStyling: true,
-    })
-
-    const input = wrapper.find('input')
-
-    expect(input.element.classList).toContain('form-control')
-    expect(input.element.classList).toContain('someClass')
-
-    await wrapper.setProps({
-      inputClass: { someClass: true },
-      bootstrapStyling: true,
-    })
-
-    expect(input.element.classList).toContain('form-control')
-    expect(input.element.classList).toContain('someClass')
-  })
-
   it('can be disabled', async () => {
     await wrapper.setProps({
       disabled: true,
@@ -236,5 +206,45 @@ describe('DateInput shallowMounted with showCalendarOnFocus', () => {
 
     await input.trigger('focus')
     expect(wrapper.emitted('open')).toBeTruthy()
+  })
+})
+
+describe('DateInput shallowMounted with bootstrap styling', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = shallowMount(DateInput, {
+      propsData: {
+        bootstrapStyling: true,
+      },
+    })
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  it('adds bootstrap classes', async () => {
+    const input = wrapper.find('input')
+
+    expect(input.element.classList).toContain('form-control')
+  })
+
+  it('appends bootstrap classes', async () => {
+    await wrapper.setProps({
+      inputClass: 'someClass',
+    })
+
+    const input = wrapper.find('input')
+
+    expect(input.element.classList).toContain('form-control')
+    expect(input.element.classList).toContain('someClass')
+
+    await wrapper.setProps({
+      inputClass: { someClass: true },
+    })
+
+    expect(input.element.classList).toContain('form-control')
+    expect(input.element.classList).toContain('someClass')
   })
 })

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -39,7 +39,6 @@ describe('DateInput shallowMounted', () => {
     const dateString = '04.06.2018'
 
     input.setValue(dateString)
-    await input.trigger('keyup')
     await input.trigger('keydown.enter')
 
     expect(input.element.value).toEqual(dateString)
@@ -54,7 +53,6 @@ describe('DateInput shallowMounted', () => {
     const dateString = '4.6.2018'
 
     input.setValue(dateString)
-    await input.trigger('keyup')
     await input.trigger('keydown.enter')
 
     expect(input.element.value).toEqual(dateString)
@@ -69,7 +67,6 @@ describe('DateInput shallowMounted', () => {
     const dateString = '24/06/2018'
 
     input.setValue(dateString)
-    await input.trigger('keyup')
     await input.trigger('keydown.enter')
 
     expect(input.element.value).toEqual(dateString)
@@ -84,7 +81,6 @@ describe('DateInput shallowMounted', () => {
     const dateString = '24 06 2018'
 
     input.setValue(dateString)
-    await input.trigger('keyup')
     await input.trigger('keydown.enter')
 
     expect(input.element.value).toEqual(dateString)
@@ -137,7 +133,6 @@ describe('DateInput shallowMounted', () => {
     const input = wrapper.find('input')
 
     input.setValue('2018-04-24')
-    await input.trigger('keyup')
     await input.trigger('keydown.enter')
 
     expect(wrapper.emitted('typed-date')).not.toBeDefined()
@@ -159,12 +154,14 @@ describe('Datepicker mounted', () => {
     wrapper.destroy()
   })
 
-  it('sets the date on `select-typed-date` event', () => {
+  it('sets the date and closes the calendar', () => {
     const today = new Date()
 
+    wrapper.vm.open()
     wrapper.vm.selectTypedDate(today)
 
     expect(wrapper.vm.selectedDate).toEqual(today)
+    expect(wrapper.vm.isOpen).toBeFalsy()
   })
 
   it('emits `selected` when a valid date is typed and the `enter` key is pressed', async () => {
@@ -185,7 +182,6 @@ describe('Datepicker mounted', () => {
     const input = wrapper.find('input')
 
     input.setValue('invalid date')
-    await input.trigger('keyup')
     await input.trigger('keydown.enter')
 
     expect(wrapper.emitted('selected')).toBeUndefined()
@@ -194,7 +190,8 @@ describe('Datepicker mounted', () => {
   it('shows the correct month as you type', async () => {
     const input = wrapper.find('input')
 
-    await input.trigger('click')
+    await wrapper.vm.open()
+
     input.setValue('Jan')
     await input.trigger('keyup')
 
@@ -211,7 +208,6 @@ describe('Datepicker mounted', () => {
     const input = wrapper.find('input')
 
     input.setValue('2018-04-24')
-    await input.trigger('keyup')
     await input.trigger('blur')
 
     expect(input.element.value).toEqual('24 Apr 2018')
@@ -220,11 +216,7 @@ describe('Datepicker mounted', () => {
   it('clears an invalid date when the input field is blurred', async () => {
     const input = wrapper.find('input')
 
-    await input.trigger('click')
-    expect(wrapper.vm.isOpen).toBeTruthy()
-
     input.setValue('invalid date')
-    await input.trigger('keyup')
     await input.trigger('blur')
 
     expect(input.element.value).toBe('')
@@ -264,9 +256,7 @@ describe('Datepicker mounted', () => {
   it('resets the date correctly', async () => {
     const input = wrapper.find('input')
 
-    await input.trigger('click')
     input.setValue('1 Jan 2000')
-    await input.trigger('keyup')
     await input.trigger('keydown.enter')
 
     expect(wrapper.vm.selectedDate).toEqual(new Date(2000, 0, 1))

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -223,36 +223,6 @@ describe('Datepicker mounted', () => {
     expect(wrapper.vm.selectedDate).toBeNull()
   })
 
-  it('closes via the calendar button when showCalendarOnFocus = true, despite input being focused', async () => {
-    await wrapper.setProps({
-      calendarButton: true,
-      showCalendarOnFocus: true,
-    })
-
-    const input = wrapper.find('input')
-    const calendarButton = wrapper.find('button[data-test-calendar-button]')
-
-    await input.trigger('focus')
-    expect(wrapper.vm.isOpen).toBeTruthy()
-
-    await calendarButton.trigger('click')
-    expect(wrapper.vm.isOpen).toBeFalsy()
-  })
-
-  it('toggles on clicking the input when showCalendarOnFocus = true', async () => {
-    await wrapper.setProps({
-      showCalendarOnFocus: true,
-    })
-
-    const input = wrapper.find('input')
-
-    await input.trigger('click')
-    expect(wrapper.vm.isOpen).toBeTruthy()
-
-    await input.trigger('click')
-    expect(wrapper.vm.isOpen).toBeFalsy()
-  })
-
   it('resets the date correctly', async () => {
     const input = wrapper.find('input')
 
@@ -285,5 +255,47 @@ describe('Datepicker mounted', () => {
     await input.trigger('keyup.space')
 
     expect(wrapper.vm.isOpen).toBeTruthy()
+  })
+})
+
+describe('Datepicker mounted with showCalendarOnFocus', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(Datepicker, {
+      propsData: {
+        typeable: true,
+        showCalendarOnFocus: true,
+      },
+    })
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  it('toggles on clicking the input', async () => {
+    const input = wrapper.find('input')
+
+    await input.trigger('click')
+    expect(wrapper.vm.isOpen).toBeTruthy()
+
+    await input.trigger('click')
+    expect(wrapper.vm.isOpen).toBeFalsy()
+  })
+
+  it('closes via the calendar button, despite input being focused', async () => {
+    await wrapper.setProps({
+      calendarButton: true,
+    })
+
+    const input = wrapper.find('input')
+    const calendarButton = wrapper.find('button[data-test-calendar-button]')
+
+    await input.trigger('focus')
+    expect(wrapper.vm.isOpen).toBeTruthy()
+
+    await calendarButton.trigger('click')
+    expect(wrapper.vm.isOpen).toBeFalsy()
   })
 })

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -306,6 +306,42 @@ describe('Datepicker mounted', () => {
     wrapper.destroy()
   })
 
+  it('opens in `day` view', async () => {
+    await wrapper.vm.open()
+
+    expect(wrapper.vm.computedInitialView).toEqual('day')
+    expect(wrapper.vm.picker).toEqual('PickerDay')
+  })
+
+  it('opens in `month` view', async () => {
+    await wrapper.setProps({
+      initialView: 'month',
+    })
+    await wrapper.vm.open()
+
+    expect(wrapper.vm.computedInitialView).toEqual('month')
+    expect(wrapper.vm.picker).toEqual('PickerMonth')
+  })
+
+  it('opens in `year` view', async () => {
+    await wrapper.setProps({
+      initialView: 'year',
+    })
+    await wrapper.vm.open()
+
+    expect(wrapper.vm.computedInitialView).toEqual('year')
+    expect(wrapper.vm.picker).toEqual('PickerYear')
+  })
+
+  it('does not open if the calendar is disabled', async () => {
+    await wrapper.setProps({
+      disabled: true,
+    })
+    await wrapper.vm.open()
+
+    expect(wrapper.vm.isOpen).toBeFalsy()
+  })
+
   it('emits blur', async () => {
     const input = wrapper.find('input')
     await input.trigger('blur')
@@ -320,8 +356,8 @@ describe('Datepicker mounted', () => {
 
   it('toggles when the input field is clicked', async () => {
     const input = wrapper.find('input')
-    await input.trigger('click')
 
+    await input.trigger('click')
     expect(wrapper.vm.isOpen).toBeTruthy()
 
     await input.trigger('click')
@@ -1135,51 +1171,6 @@ describe('Datepicker mounted inline and attached to body', () => {
     await anotherDate.trigger('click')
 
     expect(document.activeElement).toBe(anotherDate.element)
-  })
-})
-
-describe('Datepicker mounted with initial-view', () => {
-  let wrapper
-
-  beforeEach(() => {
-    wrapper = mount(Datepicker)
-  })
-
-  afterEach(() => {
-    wrapper.destroy()
-  })
-
-  it('opens in `day` view', async () => {
-    await wrapper.vm.open()
-
-    expect(wrapper.vm.computedInitialView).toEqual('day')
-    expect(wrapper.vm.picker).toEqual('PickerDay')
-  })
-
-  it('opens in `month` view', async () => {
-    await wrapper.setProps({
-      initialView: 'month',
-    })
-    await wrapper.vm.open()
-    expect(wrapper.vm.computedInitialView).toEqual('month')
-    expect(wrapper.vm.picker).toEqual('PickerMonth')
-  })
-
-  it('opens in `year` view', async () => {
-    await wrapper.setProps({
-      initialView: 'year',
-    })
-    await wrapper.vm.open()
-    expect(wrapper.vm.computedInitialView).toEqual('year')
-    expect(wrapper.vm.picker).toEqual('PickerYear')
-  })
-
-  it('does not open if the calendar is disabled', async () => {
-    await wrapper.setProps({
-      disabled: true,
-    })
-    await wrapper.vm.open()
-    expect(wrapper.vm.isOpen).toBeFalsy()
   })
 })
 

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -328,52 +328,6 @@ describe('Datepicker mounted', () => {
     expect(wrapper.vm.isOpen).toBeFalsy()
   })
 
-  it('toggles via the calendar button', async () => {
-    await wrapper.setProps({
-      calendarButton: true,
-    })
-
-    const calendarButton = wrapper.find('button[data-test-calendar-button]')
-
-    await calendarButton.trigger('click')
-    expect(wrapper.vm.isOpen).toBeTruthy()
-
-    await calendarButton.trigger('click')
-    expect(wrapper.vm.isOpen).toBeFalsy()
-  })
-
-  it('toggles via the calendar button when showCalendarOnFocus = true', async () => {
-    await wrapper.setProps({
-      calendarButton: true,
-      showCalendarOnFocus: true,
-    })
-
-    const calendarButton = wrapper.find('button[data-test-calendar-button]')
-
-    await calendarButton.trigger('click')
-    expect(wrapper.vm.isOpen).toBeTruthy()
-
-    await calendarButton.trigger('click')
-    expect(wrapper.vm.isOpen).toBeFalsy()
-  })
-
-  it('closes via the calendar button when typeable and showCalendarOnFocus = true, despite input being focused', async () => {
-    await wrapper.setProps({
-      calendarButton: true,
-      showCalendarOnFocus: true,
-      typeable: true,
-    })
-
-    const input = wrapper.find('input')
-    const calendarButton = wrapper.find('button[data-test-calendar-button]')
-
-    await input.trigger('focus')
-    expect(wrapper.vm.isOpen).toBeTruthy()
-
-    await calendarButton.trigger('click')
-    expect(wrapper.vm.isOpen).toBeFalsy()
-  })
-
   it('selects an edge date', async () => {
     await wrapper.setProps({
       value: new Date(2020, 0, 1),
@@ -430,6 +384,62 @@ describe('Datepicker mounted with showCalendarOnFocus', () => {
     await openDate.trigger('click')
 
     expect(document.activeElement).toBe(document.body)
+  })
+})
+
+describe('Datepicker mounted with calendar button', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(Datepicker, {
+      propsData: {
+        calendarButton: true,
+      },
+    })
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  it('toggles via the calendar button', async () => {
+    const calendarButton = wrapper.find('button[data-test-calendar-button]')
+
+    await calendarButton.trigger('click')
+    expect(wrapper.vm.isOpen).toBeTruthy()
+
+    await calendarButton.trigger('click')
+    expect(wrapper.vm.isOpen).toBeFalsy()
+  })
+
+  it('toggles via the calendar button when showCalendarOnFocus = true', async () => {
+    await wrapper.setProps({
+      showCalendarOnFocus: true,
+    })
+
+    const calendarButton = wrapper.find('button[data-test-calendar-button]')
+
+    await calendarButton.trigger('click')
+    expect(wrapper.vm.isOpen).toBeTruthy()
+
+    await calendarButton.trigger('click')
+    expect(wrapper.vm.isOpen).toBeFalsy()
+  })
+
+  it('closes via the calendar button when typeable and showCalendarOnFocus = true, despite input being focused', async () => {
+    await wrapper.setProps({
+      showCalendarOnFocus: true,
+      typeable: true,
+    })
+
+    const input = wrapper.find('input')
+    const calendarButton = wrapper.find('button[data-test-calendar-button]')
+
+    await input.trigger('focus')
+    expect(wrapper.vm.isOpen).toBeTruthy()
+
+    await calendarButton.trigger('click')
+    expect(wrapper.vm.isOpen).toBeFalsy()
   })
 })
 

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -461,22 +461,6 @@ describe('Datepicker mounted with calendar button', () => {
     await calendarButton.trigger('click')
     expect(wrapper.vm.isOpen).toBeFalsy()
   })
-
-  it('closes via the calendar button when typeable and showCalendarOnFocus = true, despite input being focused', async () => {
-    await wrapper.setProps({
-      showCalendarOnFocus: true,
-      typeable: true,
-    })
-
-    const input = wrapper.find('input')
-    const calendarButton = wrapper.find('button[data-test-calendar-button]')
-
-    await input.trigger('focus')
-    expect(wrapper.vm.isOpen).toBeTruthy()
-
-    await calendarButton.trigger('click')
-    expect(wrapper.vm.isOpen).toBeFalsy()
-  })
 })
 
 describe('Datepicker mounted with slots', () => {

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -328,30 +328,6 @@ describe('Datepicker mounted', () => {
     expect(wrapper.vm.isOpen).toBeFalsy()
   })
 
-  it('opens on focusing the input when showCalendarOnFocus = true', async () => {
-    await wrapper.setProps({
-      showCalendarOnFocus: true,
-    })
-    const input = wrapper.find('input')
-
-    await input.trigger('focus')
-
-    expect(wrapper.vm.isOpen).toBeTruthy()
-  })
-
-  it('toggles on clicking the input when showCalendarOnFocus = true', async () => {
-    await wrapper.setProps({
-      showCalendarOnFocus: true,
-    })
-    const input = wrapper.find('input')
-
-    await input.trigger('click')
-    expect(wrapper.vm.isOpen).toBeTruthy()
-
-    await input.trigger('click')
-    expect(wrapper.vm.isOpen).toBeFalsy()
-  })
-
   it('toggles via the calendar button', async () => {
     await wrapper.setProps({
       calendarButton: true,
@@ -409,6 +385,51 @@ describe('Datepicker mounted', () => {
     await lastCell.trigger('click')
 
     expect(wrapper.vm.selectedDate).toStrictEqual(new Date(2020, 1, 1))
+  })
+})
+
+describe('Datepicker mounted with showCalendarOnFocus', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(Datepicker, {
+      propsData: {
+        showCalendarOnFocus: true,
+      },
+    })
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  it('opens on focusing the input', async () => {
+    const input = wrapper.find('input')
+
+    await input.trigger('focus')
+
+    expect(wrapper.vm.isOpen).toBeTruthy()
+  })
+
+  it('toggles on clicking the input', async () => {
+    const input = wrapper.find('input')
+
+    await input.trigger('click')
+    expect(wrapper.vm.isOpen).toBeTruthy()
+
+    await input.trigger('click')
+    expect(wrapper.vm.isOpen).toBeFalsy()
+  })
+
+  it('does not focus the input on selecting a date', async () => {
+    const input = wrapper.find('input')
+
+    await input.trigger('click')
+
+    const openDate = wrapper.find('button.open')
+    await openDate.trigger('click')
+
+    expect(document.activeElement).toBe(document.body)
   })
 })
 
@@ -514,21 +535,6 @@ describe('Datepicker mounted and attached to body', () => {
     await prevButton.trigger('keydown.up')
 
     expect(document.activeElement).not.toBe(input.element)
-  })
-
-  it('does not focus the input on selecting a date when show-calendar-on-focus = true', async () => {
-    await wrapper.setProps({
-      showCalendarOnFocus: true,
-    })
-
-    const input = wrapper.find('input')
-
-    await input.trigger('click')
-
-    const openDate = wrapper.find('button.open')
-    await openDate.trigger('click')
-
-    expect(document.activeElement).toBe(document.body)
   })
 
   it('tabs away from a closed calendar', async () => {

--- a/test/unit/specs/Datepicker/openDate.spec.js
+++ b/test/unit/specs/Datepicker/openDate.spec.js
@@ -1,6 +1,24 @@
 import { shallowMount } from '@vue/test-utils'
 import Datepicker from '~/components/Datepicker.vue'
 
+describe('Datepicker shallowMounted', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = shallowMount(Datepicker)
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  it("shows today's date if no open date is set", () => {
+    const today = new Date()
+    expect(wrapper.vm.pageDate.getMonth()).toEqual(today.getMonth())
+    expect(wrapper.vm.pageDate.getFullYear()).toEqual(today.getFullYear())
+  })
+})
+
 describe('Datepicker shallowMounted with open date', () => {
   let wrapper
   const openDate = new Date(2016, 9, 12)
@@ -36,12 +54,5 @@ describe('Datepicker shallowMounted with open date', () => {
     wrapper.vm.handleSelect({ timestamp: newDate.valueOf() })
     expect(wrapper.vm.pageDate.getMonth()).toEqual(10)
     expect(wrapper.vm.pageDate.getFullYear()).toEqual(2018)
-  })
-
-  it("shows today's date if no open date is set", () => {
-    wrapper = shallowMount(Datepicker)
-    const today = new Date()
-    expect(wrapper.vm.pageDate.getMonth()).toEqual(today.getMonth())
-    expect(wrapper.vm.pageDate.getFullYear()).toEqual(today.getFullYear())
   })
 })


### PR DESCRIPTION
This fixes a timezone problem in the CellNavigation e2e tests.

JavaScript interprets strings that are formatted in a simplified iso8601 format as being in UTC timezone i.e. unless you happen to be in a UTC timezone, `new Date('2000-01-01')` is not the same as `new Date(2000, 0, 1)`. 

To avoid this problem, this PR converts dates used in the e2e tests to the interpreter's local timezone.