### PR TITLE
Revisit events

### DIFF
--- a/docs/guide/Events/README.md
+++ b/docs/guide/Events/README.md
@@ -2,16 +2,16 @@
 
 These events are emitted on actions in the datepicker
 
-| Event                                           | Output      | Description                       |
-| ----------------------------------------------- | ----------- | --------------------------------- |
-| changed                                         | Date\|null | The selected date has been changed |
-| changed-month                                   | Object      | Month page has been changed       |
-| changed-year                                    | Object      | Year page has been changed        |
-| changed-decade                                  | Object      | Decade page has been changed      |
-| cleared                                         |             | Selected date has been cleared    |
-| closed                                          |             | The picker has been closed        |
-| input                                           | Date\|null | A date has been selected           |
-| opened                                          |             | The picker has been opened        |
-| selected <br/>_(deprecated in favour of input)_ | Date\|null | A date has been selected           |
-| blur                                            |             | Input blur event                  |
-| focus                                           |             | Input focus event                 |
+| Event                                           | Output      | Description                    |
+| ----------------------------------------------- | ----------- |--------------------------------|
+| changed                                         | Date\|null                           | The selected date has been changed |
+| changed-month                                   | Object      | Month page has been changed    |
+| changed-year                                    | Object      | Year page has been changed     |
+| changed-decade                                  | Object      | Decade page has been changed   |
+| cleared                                         |             | Selected date has been cleared |
+| closed                                          |             | The picker has been closed     |
+| input                                           | Date\|null                           | A date has been selected           |
+| opened                                          |             | The picker has been opened     |
+| selected <br/>_(deprecated in favour of input)_ | Date\|null                           | A date has been selected           |
+| blur                                            |             | Datepicker has lost focus      |
+| focus                                           |             | Datepicker has been focused    |

--- a/docs/guide/Events/README.md
+++ b/docs/guide/Events/README.md
@@ -2,15 +2,15 @@
 
 These events are emitted on actions in the datepicker
 
-| Event             | Output     | Description                       |
-| ----------------- | ---------- | --------------------------------- |
-| changed-month     | Object     | Month page has been changed       |
-| changed-year      | Object     | Year page has been changed        |
-| changed-decade    | Object     | Decade page has been changed      |
-| cleared           |            | Selected date has been cleared    |
-| closed            |            | The picker has been closed        |
-| input             | Date\|null | Input value has been modified     |
-| opened            |            | The picker has been opened        |
-| selected          | Date\|null | A date has been selected          |
-| blur              |            | Input blur event                  |
-| focus             |            | Input focus event                 |
+| Event                                           | Output     | Description                           |
+|-------------------------------------------------| ---------- | ------------------------------------- |
+| changed-month                                   | Object     | Month page has been changed           |
+| changed-year                                    | Object     | Year page has been changed            |
+| changed-decade                                  | Object     | Decade page has been changed          |
+| cleared                                         |            | Selected date has been cleared        |
+| closed                                          |            | The picker has been closed            |
+| input                                           | Date\|null | A date has been selected              |
+| opened                                          |            | The picker has been opened            |
+| selected <br/>*(deprecated in favour of input)* | Date\|null | A date has been selected |
+| blur                                            |            | Input blur event                      |
+| focus                                           |            | Input focus event                     |

--- a/docs/guide/Events/README.md
+++ b/docs/guide/Events/README.md
@@ -2,15 +2,16 @@
 
 These events are emitted on actions in the datepicker
 
-| Event                                           | Output     | Description                           |
-|-------------------------------------------------| ---------- | ------------------------------------- |
-| changed-month                                   | Object     | Month page has been changed           |
-| changed-year                                    | Object     | Year page has been changed            |
-| changed-decade                                  | Object     | Decade page has been changed          |
-| cleared                                         |            | Selected date has been cleared        |
-| closed                                          |            | The picker has been closed            |
-| input                                           | Date\|null | A date has been selected              |
-| opened                                          |            | The picker has been opened            |
-| selected <br/>*(deprecated in favour of input)* | Date\|null | A date has been selected |
-| blur                                            |            | Input blur event                      |
-| focus                                           |            | Input focus event                     |
+| Event                                           | Output      | Description                       |
+| ----------------------------------------------- | ----------- | --------------------------------- |
+| changed                                         | Date\|null | The selected date has been changed |
+| changed-month                                   | Object      | Month page has been changed       |
+| changed-year                                    | Object      | Year page has been changed        |
+| changed-decade                                  | Object      | Decade page has been changed      |
+| cleared                                         |             | Selected date has been cleared    |
+| closed                                          |             | The picker has been closed        |
+| input                                           | Date\|null | A date has been selected           |
+| opened                                          |             | The picker has been opened        |
+| selected <br/>_(deprecated in favour of input)_ | Date\|null | A date has been selected           |
+| blur                                            |             | Input blur event                  |
+| focus                                           |             | Input focus event                 |

--- a/docs/guide/ParsingDates/README.md
+++ b/docs/guide/ParsingDates/README.md
@@ -3,12 +3,13 @@
 ## Default parsing
 When you type into a `typeable` datepicker, each time you 'key-up', the datepicker
 will try to parse your input to a valid date. When the input field loses focus, the
-date is either formatted, or cleared if no valid is found.
+date is either formatted, or cleared if no valid date is found.
 
-*N.B. Since version 5.0, the datepicker no longer submits the date each time a valid
-date is typed. A typed date is only submitted - and a `selected` event fired - a) on pressing
-the enter key, or b) when the datepicker loses focus entirely. `input` events, however,
-continue to be fired each time a change in the input field occurs and a valid date is detected.*
+*N.B. Since version 5.0, the datepicker no longer submits the date each time a
+valid date is typed. A typed date is only submitted a) on pressing the enter key,
+or b) when the datepicker loses focus entirely. When this happens, both an
+`input` and `selected` event are fired, however, the latter is deprecated and will
+be dropped in the next major version.*
 
 
 ```vue

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -192,7 +192,7 @@ export default {
       }
     },
     /**
-     * Validate typedDate and emit a `blur` event
+     * Validates typedDate
      */
     handleInputBlur() {
       if (this.showCalendarOnFocus && !this.isOpen) {
@@ -203,7 +203,6 @@ export default {
         this.formatTypedDate()
       }
       this.isInputFocused = false
-      this.$emit('blur')
     },
     /**
      * Resets `shouldToggleOnFocus` to true
@@ -232,7 +231,7 @@ export default {
       }
     },
     /**
-     * Emits a `focus` event and opens the calendar when `show-calendar-on-focus` is true
+     * Opens the calendar when `show-calendar-on-focus` is true
      */
     handleInputFocus() {
       this.isInputFocused = true
@@ -248,8 +247,6 @@ export default {
           this.shouldToggleOnClick = true
         }, 300)
       }
-
-      this.$emit('focus')
     },
     /**
      * Opens the calendar, or sets the focus to the next focusable element down

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -462,6 +462,17 @@ export default {
         this.closeByClickOutside()
       }
     },
+    dateChanged(date) {
+      if (!this.selectedDate && !date) {
+        return false
+      }
+
+      if (this.selectedDate && date) {
+        return date.valueOf() !== this.selectedDate.valueOf()
+      }
+
+      return true
+    },
     /**
      * Closes the calendar when no element within it has focus
      */
@@ -686,6 +697,10 @@ export default {
      * @param {Date|null} date
      */
     selectDate(date) {
+      if (this.dateChanged(date)) {
+        this.$emit('changed', date)
+      }
+
       this.setValue(date)
       this.$emit('input', date)
       this.$emit('selected', date)
@@ -708,19 +723,8 @@ export default {
     selectTypedDateOnLosingFocus() {
       const parsedDate = this.$refs.dateInput.parseInput()
       const date = this.utils.isValidDate(parsedDate) ? parsedDate : null
-      const hasChanged = () => {
-        if (!this.selectedDate && !date) {
-          return false
-        }
 
-        if (this.selectedDate && date) {
-          return date.valueOf() !== this.selectedDate.valueOf()
-        }
-
-        return true
-      }
-
-      if (hasChanged()) {
+      if (this.dateChanged(date)) {
         this.selectDate(date)
       }
     },

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -518,7 +518,7 @@ export default {
       }
 
       this.$refs.dateInput.typedDate = ''
-      this.selectDate(cell.timestamp)
+      this.selectDate(new Date(cell.timestamp))
       this.focus.delay = cell.isNextMonth ? this.slideDuration : 0
       this.focus.refs = this.isInline ? ['tabbableCell'] : ['input']
       this.close()
@@ -687,14 +687,12 @@ export default {
     },
     /**
      * Select the date
-     * @param {Number} timestamp
+     * @param {Date|null} date
      */
-    selectDate(timestamp) {
-      const date = new Date(timestamp)
-
+    selectDate(date) {
       this.setValue(date)
-      this.$emit('selected', date)
       this.$emit('input', date)
+      this.$emit('selected', date)
     },
     /**
      * Select the date from a 'select-typed-date' event

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -374,7 +374,7 @@ export default {
 
       if (isNoLongerActive && this.typeable) {
         this.skipReviewFocus = true
-        this.setTypedDateOnLosingFocus()
+        this.selectTypedDateOnLosingFocus()
 
         this.$nextTick(() => {
           this.skipReviewFocus = false
@@ -711,6 +711,30 @@ export default {
       }
     },
     /**
+     * Selects the typed date when the datepicker loses focus, provided it's valid and differs from the current selected date
+     */
+    selectTypedDateOnLosingFocus() {
+      const parsedDate = this.$refs.dateInput.parseInput()
+      const date = this.utils.isValidDate(parsedDate) ? parsedDate : null
+      const hasChanged = () => {
+        if (!this.selectedDate && !date) {
+          return false
+        }
+
+        if (this.selectedDate && date) {
+          return date.valueOf() !== this.selectedDate.valueOf()
+        }
+
+        return true
+      }
+
+      if (hasChanged()) {
+        this.setValue(date)
+        this.$emit('input', date)
+        this.$emit('selected', date)
+      }
+    },
+    /**
      * Sets the initial picker page view: day, month or year
      */
     setInitialView() {
@@ -758,30 +782,6 @@ export default {
       const durationInSecs = window.getComputedStyle(cells).transitionDuration
 
       this.slideDuration = parseFloat(durationInSecs) * 1000
-    },
-    /**
-     * Selects the typed date when the datepicker loses focus, provided it's valid and differs from the current selected date
-     */
-    setTypedDateOnLosingFocus() {
-      const parsedDate = this.$refs.dateInput.parseInput()
-      const date = this.utils.isValidDate(parsedDate) ? parsedDate : null
-      const hasChanged = () => {
-        if (!this.selectedDate && !date) {
-          return false
-        }
-
-        if (this.selectedDate && date) {
-          return date.valueOf() !== this.selectedDate.valueOf()
-        }
-
-        return true
-      }
-
-      if (hasChanged()) {
-        this.setValue(date)
-        this.$emit('input', date)
-        this.$emit('selected', date)
-      }
     },
     /**
      * Set the datepicker value (and, if typeable, update `latestValidTypedDate`)

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -609,8 +609,10 @@ export default {
           this.$emit('input', parsedValue)
         }
         this.setValue(parsedValue)
-      } else if (this.typeable) {
-        this.latestValidTypedDate = this.computedOpenDate
+      }
+
+      if (this.typeable) {
+        this.latestValidTypedDate = this.selectedDate || this.computedOpenDate
       }
 
       if (this.isInline) {

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -424,13 +424,9 @@ export default {
         return
       }
 
-      this.selectedDate = null
+      this.selectDate(null)
       this.focus.refs = ['input']
       this.close()
-      this.setPageDate()
-
-      this.$emit('selected', null)
-      this.$emit('input', null)
       this.$emit('cleared')
     },
     /**
@@ -699,10 +695,8 @@ export default {
      * @param {Date=} date
      */
     selectTypedDate(date) {
-      this.setValue(date)
+      this.selectDate(date)
       this.reviewFocus()
-      this.$emit('input', date)
-      this.$emit('selected', date)
 
       if (this.isOpen) {
         this.close()
@@ -727,9 +721,7 @@ export default {
       }
 
       if (hasChanged()) {
-        this.setValue(date)
-        this.$emit('input', date)
-        this.$emit('selected', date)
+        this.selectDate(date)
       }
     },
     /**

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -701,6 +701,7 @@ export default {
     selectTypedDate(date) {
       this.setValue(date)
       this.reviewFocus()
+      this.$emit('input', date)
       this.$emit('selected', date)
 
       if (this.isOpen) {
@@ -776,6 +777,7 @@ export default {
 
       if (hasChanged()) {
         this.setValue(date)
+        this.$emit('input', date)
         this.$emit('selected', date)
       }
     },

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -543,7 +543,6 @@ export default {
         this.latestValidTypedDate,
       )
       this.setPageDate(date)
-      this.$emit('input', date)
 
       if (this.isPageChange(originalPageDate)) {
         this.handlePageChange({

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -692,7 +692,7 @@ export default {
     },
     /**
      * Select the date from a 'select-typed-date' event
-     * @param {Date=} date
+     * @param {Date|null} date
      */
     selectTypedDate(date) {
       this.selectDate(date)

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -38,10 +38,8 @@
       :translation="translation"
       :typeable="typeable"
       :use-utc="useUtc"
-      @blur="handleInputBlur"
       @clear-date="clearDate"
       @close="close"
-      @focus="handleInputFocus"
       @open="open"
       @select-typed-date="selectTypedDate"
       @set-focus="setFocus($event)"
@@ -367,18 +365,12 @@ export default {
       }
     },
     isActive(hasJustBecomeActive, isNoLongerActive) {
-      if (hasJustBecomeActive && this.inline) {
-        this.setNavElementsFocusedIndex()
-        this.tabToCorrectInlineCell()
+      if (hasJustBecomeActive) {
+        this.datepickerIsActive()
       }
 
-      if (isNoLongerActive && this.typeable) {
-        this.skipReviewFocus = true
-        this.selectTypedDateOnLosingFocus()
-
-        this.$nextTick(() => {
-          this.skipReviewFocus = false
-        })
+      if (isNoLongerActive) {
+        this.datepickerIsInactive()
       }
     },
     latestValidTypedDate(date) {
@@ -473,6 +465,26 @@ export default {
 
       return true
     },
+    datepickerIsActive() {
+      this.$emit('focus')
+
+      if (this.inline) {
+        this.setNavElementsFocusedIndex()
+        this.tabToCorrectInlineCell()
+      }
+    },
+    datepickerIsInactive() {
+      this.$emit('blur')
+
+      if (this.typeable) {
+        this.skipReviewFocus = true
+        this.selectTypedDateOnLosingFocus()
+
+        this.$nextTick(() => {
+          this.skipReviewFocus = false
+        })
+      }
+    },
     /**
      * Closes the calendar when no element within it has focus
      */
@@ -491,18 +503,6 @@ export default {
           this.closeIfNotFocused()
         })
       }
-    },
-    /**
-     * Emits a 'blur' event
-     */
-    handleInputBlur() {
-      this.$emit('blur')
-    },
-    /**
-     * Emits a 'focus' event
-     */
-    handleInputFocus() {
-      this.$emit('focus')
     },
     /**
      * Set the new pageDate, focus the relevant element and emit a `changed-<view>` event

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -354,6 +354,25 @@ describe('Datepicker mounted', () => {
     expect(wrapper.emitted('focus')).toBeTruthy()
   })
 
+  it('emits changed', async () => {
+    await wrapper.vm.open()
+
+    const dayCell = wrapper.findAll('button').at(10)
+
+    await dayCell.trigger('click')
+    expect(wrapper.emitted('changed')).toHaveLength(1)
+
+    await wrapper.vm.open()
+    await dayCell.trigger('click')
+    expect(wrapper.emitted('changed')).toHaveLength(1)
+
+    await wrapper.vm.open()
+
+    const differentDayCell = wrapper.findAll('button').at(11)
+    await differentDayCell.trigger('click')
+    expect(wrapper.emitted('changed')).toHaveLength(2)
+  })
+
   it('toggles when the input field is clicked', async () => {
     const input = wrapper.find('input')
 

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -342,16 +342,19 @@ describe('Datepicker mounted', () => {
     expect(wrapper.vm.isOpen).toBeFalsy()
   })
 
-  it('emits blur', async () => {
-    const input = wrapper.find('input')
-    await input.trigger('blur')
-    expect(wrapper.emitted('blur')).toBeTruthy()
-  })
-
   it('emits focus', async () => {
     const input = wrapper.find('input')
-    await input.trigger('focus')
+    await input.trigger('focusin')
+
     expect(wrapper.emitted('focus')).toBeTruthy()
+  })
+
+  it('emits blur', async () => {
+    const input = wrapper.find('input')
+    await input.trigger('focusin')
+    await input.trigger('focusout')
+
+    expect(wrapper.emitted('blur')).toBeTruthy()
   })
 
   it('emits changed', async () => {


### PR DESCRIPTION
This PR emits a`changed` event whenever the selected date is changed. This is also the case when the selected date changes from `null` to a valid date and vice versa.

Further, it alters the way the `focus` and `blur` events work: instead of relating solely to the focus status of the input field, these events now relate to the focus status of the datepicker *as a whole*. Therefore, an inline datepicker will now emit a `focus` event when any element within it first becomes focused - and a `blur` event when no elements within it are focused any longer.