### PR TITLE
Watch disabled dates

### DIFF
--- a/docs/guide/DisabledDates/README.md
+++ b/docs/guide/DisabledDates/README.md
@@ -1,12 +1,19 @@
 # Disabled Dates
 
-Dates can be disabled in a number of ways.
+Dates can be disabled via the `disabled-dates` prop in a number of ways.
 
 ```vue
 <template>
   <DatePicker :disabled-dates="state.disabledDates"></DatePicker>
 </template>
 ```
+
+::: tip NOTE
+Since version 5, the `disabled-dates` prop is constantly watched for any changes.
+If/when a date is disabled, its value becomes `null` and both `input` and `changed`
+events are emitted. These same events are emitted again if/when the date is no
+longer disabled.
+:::
 
 ## Disable up to a specific date
 
@@ -18,7 +25,7 @@ var state = {
 }
 ```
 
-Everything before 2016-01-05 is disabled
+All dates before 2016-01-05 are disabled.
 
 ## Disable from a specific date
 
@@ -30,7 +37,7 @@ var state = {
 }
 ```
 
-Everything after 2016-01-26 is disabled
+All dates after 2016-01-26 are disabled.
 
 ## Disable specific days in each week
 
@@ -42,7 +49,7 @@ var state = {
 }
 ```
 
-Every Saturday and Sunday is disabled
+Every Saturday and Sunday is disabled.
 
 ## Disable specific days of each month
 
@@ -54,7 +61,7 @@ var state = {
 }
 ```
 
-Disable 29th, 30th and 31st of each month
+29th, 30th and 31st of each month are disabled.
 
 ## Disable specific days from an array
 
@@ -70,12 +77,9 @@ var state = {
 }
 ```
 
-Following dates are disabled:
-2016-10-16
-2016-10-17
-2016-10-18
+The following dates are disabled: 2016-10-16, 2016-10-17, 2016-10-18.
 
-## Disable in given ranges
+## Disable within given ranges
 
 ::: tip IMPORTANT
 Both `to` and `from` properties are required to define a range of dates to highlight.
@@ -98,14 +102,14 @@ var state = {
 }
 ```
 
-The dates between 2016-12-24 - 2016-12-31 and 2017-02-11 - 2017-03-26 are disabled
+The dates from 2016-12-26 to 2016-12-29 (inclusive) and 2017-02-13 to 2017-03-24
+(inclusive) are disabled.
 
-## Disable after own logic
+## Disable based on custom logic
 
-A custom function that returns `true` if the date is disabled.
-This can be used for writing your own logic to disable a date if none
-of the above conditions serve your purpose.
-This function should accept a date and return `true` if it is disabled
+If none of the above scenarios serve your purpose, you can write your own
+`customPredictor` function to determine when a date should be disabled. This
+should accept a date and return `true` if it is disabled.
 
 ```js
 var state = {
@@ -120,4 +124,4 @@ var state = {
 }
 ```
 
-Every date that is a multiple of 5 is disabled
+Every date that is a multiple of 5 is disabled.

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -379,9 +379,21 @@ export default {
     openDate() {
       this.setPageDate()
     },
-    value(value) {
-      const parsedValue = this.parseValue(value)
-      this.setValue(parsedValue)
+    value: {
+      handler(newValue, oldValue) {
+        let parsedValue = this.parseValue(newValue)
+        const oldParsedValue = this.parseValue(oldValue)
+
+        if (!this.utils.compareDates(parsedValue, oldParsedValue)) {
+          const isDateDisabled = parsedValue && this.isDateDisabled(parsedValue)
+
+          if (isDateDisabled) {
+            parsedValue = null
+          }
+          this.setValue(parsedValue)
+        }
+      },
+      immediate: true,
     },
     view(newView, oldView) {
       this.handleViewChange(newView, oldView)
@@ -605,18 +617,7 @@ export default {
     /**
      * Initiate the component
      */
-    // eslint-disable-next-line complexity,max-statements
     init() {
-      if (this.value) {
-        let parsedValue = this.parseValue(this.value)
-        const isDateDisabled = parsedValue && this.isDateDisabled(parsedValue)
-
-        if (isDateDisabled) {
-          parsedValue = null
-        }
-        this.setValue(parsedValue)
-      }
-
       if (this.typeable) {
         this.latestValidTypedDate = this.selectedDate || this.computedOpenDate
       }

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -359,6 +359,26 @@ export default {
     },
   },
   watch: {
+    disabledDates: {
+      // eslint-disable-next-line complexity
+      handler() {
+        const selectedDate = this.selectedDate || this.parseValue(this.value)
+        if (!selectedDate) {
+          return
+        }
+
+        const isDateDisabled = this.isDateDisabled(selectedDate)
+
+        if (isDateDisabled) {
+          if (this.selectedDate) {
+            this.selectDate(null)
+          }
+        } else if (this.dateChanged(selectedDate)) {
+          this.selectDate(selectedDate)
+        }
+      },
+      deep: true,
+    },
     initialView() {
       if (this.isOpen) {
         this.setInitialView()

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -667,16 +667,15 @@ export default {
     },
     /**
      * Parse a datepicker value from string/number to date
-     * @param   {Date|String|Number|null} date
-     * @returns {Date}
+     * @param   {Date|String|Number|undefined} date
+     * @returns {Date|null}
      */
     parseValue(date) {
-      let dateTemp = date
-      if (typeof dateTemp === 'string' || typeof dateTemp === 'number') {
-        const parsed = new Date(dateTemp)
-        dateTemp = Number.isNaN(parsed.valueOf()) ? null : parsed
+      if (typeof date === 'string' || typeof date === 'number') {
+        const parsed = new Date(date)
+        return this.utils.isValidDate(parsed) ? parsed : null
       }
-      return dateTemp
+      return this.utils.isValidDate(date) ? date : null
     },
     /**
      * Focus the open date, or close the calendar if already focused

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -613,7 +613,6 @@ export default {
 
         if (isDateDisabled) {
           parsedValue = null
-          this.$emit('input', parsedValue)
         }
         this.setValue(parsedValue)
       }

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -326,9 +326,7 @@ export default {
      * @return {Boolean}
      */
     isSelectedDate(dObj) {
-      return (
-        this.selectedDate && this.utils.compareDates(this.selectedDate, dObj)
-      )
+      return this.utils.compareDates(this.selectedDate, dObj)
     },
     /**
      * Defines the objects within the days array
@@ -352,8 +350,7 @@ export default {
         isHighlighted: this.isHighlightedDate(dObj),
         isHighlightStart: this.isHighlightStart(dObj),
         isHighlightEnd: this.isHighlightEnd(dObj),
-        isOpenDate:
-          this.openDate && this.utils.compareDates(dObj, this.openDate),
+        isOpenDate: this.utils.compareDates(dObj, this.openDate),
         isToday: this.utils.compareDates(dObj, new Date()),
         isWeekend: isSaturday || isSunday,
         isSaturday,

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -148,10 +148,22 @@ const utils = {
   /**
    * Check if date1 is equivalent to date2, without comparing the time
    * @see https://stackoverflow.com/a/6202196/4455925
-   * @param {Date} date1
-   * @param {Date} date2
+   * @param {Date|null} date1
+   * @param {Date|null} date2
    */
+  // eslint-disable-next-line complexity
   compareDates(date1, date2) {
+    if (date1 === null && date2 === null) {
+      return true
+    }
+
+    if (
+      (date1 !== null && date2 === null) ||
+      (date2 !== null && date1 === null)
+    ) {
+      return false
+    }
+
     const d1 = new Date(date1.valueOf())
     const d2 = new Date(date2.valueOf())
 

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -267,7 +267,6 @@ describe('Datepicker shallowMounted', () => {
     })
 
     expect(wrapperTemp.vm.selectedDate).toEqual(null)
-    expect(wrapperTemp.emitted('input')).toBeTruthy()
 
     wrapperTemp.destroy()
   })

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -255,20 +255,17 @@ describe('Datepicker shallowMounted', () => {
     expect(wrapper.emitted('changed-decade')).toBeTruthy()
   })
 
-  it('clears date on default date disabled', async () => {
+  it('clears the date when it is disabled', async () => {
     const someDate = new Date('2021-01-15')
-    const wrapperTemp = shallowMount(Datepicker, {
-      propsData: {
-        value: someDate,
-        disabledDates: {
-          to: addDays(someDate, 1),
-        },
+
+    await wrapper.setProps({
+      value: someDate,
+      disabledDates: {
+        to: addDays(someDate, 1),
       },
     })
 
-    expect(wrapperTemp.vm.selectedDate).toEqual(null)
-
-    wrapperTemp.destroy()
+    expect(wrapper.vm.selectedDate).toBeNull()
   })
 
   it('sets the transition correctly', async () => {


### PR DESCRIPTION
Imagine you own a ski-chalet (wouldn't that be nice!) and use this datepicker to show available dates on your web site. However, you also sell your accommodation on Airbnb (or any other 3rd party web site) and use websockets (or similar) to sync the `disabled-dates` object that you use for the datepicker.

When someone makes a booking on Airbnb, you would want your datepicker to disable any date(s) a user may have selected on your web site as they are no longer available. Currently, this is not possible as the `disabled-dates` object is not being watched; it only disables dates at the moment at which the page is loaded.

This PR changes that by deep-watching the disabled dates. It also emits `changed` and `input` events when a selected date becomes disabled - and again if/when it becomes re-enabled. 
N.B. For backwards compatibility (as per my suggestions in #151), in addition to `input`, it also emits a `selected` event. Perhaps a `cleared` event should be emitted too when a date becomes disabled? I'm not sure... currently, I haven't implemented that.

A further change in this PR is to watch the `value` prop more closely... Currently, the `value` is only checked for disabled dates (within the `init` method) on mount. I've changed this so that a date `value` is nullified - if it should be disabled - not only on the initial load, but also for any subsequent changes. N.B. Unlike for changes to `disabled-dates`, I decided not to emit any events for this, my reasoning being that any change to the `value` prop could be considered a deliberate first-party action of which the consumer of the datepicker would already necessarily be aware. I'm not 100% sure about this logic, so please let me know if you think it should be changed.

You can view a demo of the functionality in the last commit. As ever, I'm most grateful for your thoughts/comments... 
