### PR TITLE
Fix focus trapping in slots

### DIFF
--- a/docs/guide/DisabledDates/README.md
+++ b/docs/guide/DisabledDates/README.md
@@ -1,12 +1,19 @@
 # Disabled Dates
 
-Dates can be disabled in a number of ways.
+Dates can be disabled via the `disabled-dates` prop in a number of ways.
 
 ```vue
 <template>
   <DatePicker :disabled-dates="state.disabledDates"></DatePicker>
 </template>
 ```
+
+::: tip NOTE
+Since version 5, the `disabled-dates` prop is constantly watched for any changes.
+If/when a date is disabled, its value becomes `null` and both `input` and `changed`
+events are emitted. These same events are emitted again if/when the date is no
+longer disabled.
+:::
 
 ## Disable up to a specific date
 
@@ -18,7 +25,7 @@ var state = {
 }
 ```
 
-Everything before 2016-01-05 is disabled
+All dates before 2016-01-05 are disabled.
 
 ## Disable from a specific date
 
@@ -30,7 +37,7 @@ var state = {
 }
 ```
 
-Everything after 2016-01-26 is disabled
+All dates after 2016-01-26 are disabled.
 
 ## Disable specific days in each week
 
@@ -42,7 +49,7 @@ var state = {
 }
 ```
 
-Every Saturday and Sunday is disabled
+Every Saturday and Sunday is disabled.
 
 ## Disable specific days of each month
 
@@ -54,7 +61,7 @@ var state = {
 }
 ```
 
-Disable 29th, 30th and 31st of each month
+29th, 30th and 31st of each month are disabled.
 
 ## Disable specific days from an array
 
@@ -70,12 +77,9 @@ var state = {
 }
 ```
 
-Following dates are disabled:
-2016-10-16
-2016-10-17
-2016-10-18
+The following dates are disabled: 2016-10-16, 2016-10-17, 2016-10-18.
 
-## Disable in given ranges
+## Disable within given ranges
 
 ::: tip IMPORTANT
 Both `to` and `from` properties are required to define a range of dates to highlight.
@@ -98,14 +102,14 @@ var state = {
 }
 ```
 
-The dates between 2016-12-24 - 2016-12-31 and 2017-02-11 - 2017-03-26 are disabled
+The dates from 2016-12-26 to 2016-12-29 (inclusive) and 2017-02-13 to 2017-03-24
+(inclusive) are disabled.
 
-## Disable after own logic
+## Disable based on custom logic
 
-A custom function that returns `true` if the date is disabled.
-This can be used for writing your own logic to disable a date if none
-of the above conditions serve your purpose.
-This function should accept a date and return `true` if it is disabled
+If none of the above scenarios serve your purpose, you can write your own
+`customPredictor` function to determine when a date should be disabled. This
+should accept a date and return `true` if it is disabled.
 
 ```js
 var state = {
@@ -120,4 +124,4 @@ var state = {
 }
 ```
 
-Every date that is a multiple of 5 is disabled
+Every date that is a multiple of 5 is disabled.

--- a/docs/guide/Migration/README.md
+++ b/docs/guide/Migration/README.md
@@ -1,10 +1,18 @@
 # Migration
 
+## 4.x.x to 5.x.x
+
+- the `selected` event has been deprecated in favour of `input`. You should therefore listen to `input` events on the datepicker, or simply bind your date via v-model: `<Datepicker v-model="myDate" />`
+- a `typeable` datepicker no longer selects the date each time the input string can be parsed to a date. Instead, a typed date is only selected - and an `input` event fired - when the input field is focused and the `enter` key is pressed, or when the datepicker loses focus entirely.
+- a new `changed` event is emitted whenever the selected date deviates from its previous value.
+- the `focus` and `blur` events now refer to the whole datepicker, not just the input field.
+- the `disabled-dates` prop is now watched for changes with the value of any selected date being nullified if that date is disabled.
+
 ## 3.x.x to 4.x.x
 
-- the html changed because of the new keyboard support. If you have any custom css it might break.
-- additional a transition element was wrapped around the picker
-- inline css class change from inline to `vdp-datepicker__calendar--inline` too not get confused with css class libraries
+- the html changed due to the new keyboard support. If you have any custom css it might break.
+- an additional transition element was wrapped around the picker
+- inline css class changed from `inline` to `vdp-datepicker__calendar--inline` to avoid any conflict with css class libraries
 
 ## 2.x.x to 3.x.x
 

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -50,6 +50,7 @@
       @keydown.enter.prevent="handleKeydownEnter"
       @keydown.esc.prevent="handleKeydownEscape"
       @keydown.space="handleKeydownSpace($event)"
+      @keydown.tab="$emit('tab', $event)"
       @keyup="handleKeyup($event)"
       @keyup.space="handleKeyupSpace($event)"
     />

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -379,9 +379,21 @@ export default {
     openDate() {
       this.setPageDate()
     },
-    value(value) {
-      const parsedValue = this.parseValue(value)
-      this.setValue(parsedValue)
+    value: {
+      handler(newValue, oldValue) {
+        let parsedValue = this.parseValue(newValue)
+        const oldParsedValue = this.parseValue(oldValue)
+
+        if (!this.utils.compareDates(parsedValue, oldParsedValue)) {
+          const isDateDisabled = parsedValue && this.isDateDisabled(parsedValue)
+
+          if (isDateDisabled) {
+            parsedValue = null
+          }
+          this.setValue(parsedValue)
+        }
+      },
+      immediate: true,
     },
     view(newView, oldView) {
       this.handleViewChange(newView, oldView)
@@ -605,18 +617,7 @@ export default {
     /**
      * Initiate the component
      */
-    // eslint-disable-next-line complexity,max-statements
     init() {
-      if (this.value) {
-        let parsedValue = this.parseValue(this.value)
-        const isDateDisabled = parsedValue && this.isDateDisabled(parsedValue)
-
-        if (isDateDisabled) {
-          parsedValue = null
-        }
-        this.setValue(parsedValue)
-      }
-
       if (this.typeable) {
         this.latestValidTypedDate = this.selectedDate || this.computedOpenDate
       }

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -359,6 +359,26 @@ export default {
     },
   },
   watch: {
+    disabledDates: {
+      // eslint-disable-next-line complexity
+      handler() {
+        const selectedDate = this.selectedDate || this.parseValue(this.value)
+        if (!selectedDate) {
+          return
+        }
+
+        const isDateDisabled = this.isDateDisabled(selectedDate)
+
+        if (isDateDisabled) {
+          if (this.selectedDate) {
+            this.selectDate(null)
+          }
+        } else if (this.dateChanged(selectedDate)) {
+          this.selectDate(selectedDate)
+        }
+      },
+      deep: true,
+    },
     initialView() {
       if (this.isOpen) {
         this.setInitialView()

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -525,14 +525,21 @@ export default {
         return
       }
 
+      const closeByClickOutside = () => {
+        this.isClickOutside = true
+        this.close()
+      }
+
       if (!this.globalDatepickerId) {
-        this.closeByClickOutside()
+        closeByClickOutside()
         return
       }
 
       if (document.datepickerId.toString() === this.datepickerId) {
         this.$nextTick(() => {
-          this.closeIfNotFocused()
+          if (!this.isActive) {
+            closeByClickOutside()
+          }
         })
       }
     },

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -667,16 +667,15 @@ export default {
     },
     /**
      * Parse a datepicker value from string/number to date
-     * @param   {Date|String|Number|null} date
-     * @returns {Date}
+     * @param   {Date|String|Number|undefined} date
+     * @returns {Date|null}
      */
     parseValue(date) {
-      let dateTemp = date
-      if (typeof dateTemp === 'string' || typeof dateTemp === 'number') {
-        const parsed = new Date(dateTemp)
-        dateTemp = Number.isNaN(parsed.valueOf()) ? null : parsed
+      if (typeof date === 'string' || typeof date === 'number') {
+        const parsed = new Date(date)
+        return this.utils.isValidDate(parsed) ? parsed : null
       }
-      return dateTemp
+      return this.utils.isValidDate(date) ? date : null
     },
     /**
      * Focus the open date, or close the calendar if already focused

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -7,7 +7,6 @@
     @focusin="handleFocusIn($event)"
     @focusout="handleFocusOut($event)"
     @keydown.esc="resetOrClose"
-    @keydown.tab="tabThroughNavigation($event)"
   >
     <DateInput
       :id="id"
@@ -43,6 +42,7 @@
       @open="open"
       @select-typed-date="selectTypedDate"
       @set-focus="setFocus($event)"
+      @tab="tabThroughNavigation"
       @typed-date="handleTypedDate"
     >
       <template #beforeDateInput>

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -613,7 +613,6 @@ export default {
 
         if (isDateDisabled) {
           parsedValue = null
-          this.$emit('input', parsedValue)
         }
         this.setValue(parsedValue)
       }

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -326,9 +326,7 @@ export default {
      * @return {Boolean}
      */
     isSelectedDate(dObj) {
-      return (
-        this.selectedDate && this.utils.compareDates(this.selectedDate, dObj)
-      )
+      return this.utils.compareDates(this.selectedDate, dObj)
     },
     /**
      * Defines the objects within the days array
@@ -352,8 +350,7 @@ export default {
         isHighlighted: this.isHighlightedDate(dObj),
         isHighlightStart: this.isHighlightStart(dObj),
         isHighlightEnd: this.isHighlightEnd(dObj),
-        isOpenDate:
-          this.openDate && this.utils.compareDates(dObj, this.openDate),
+        isOpenDate: this.utils.compareDates(dObj, this.openDate),
         isToday: this.utils.compareDates(dObj, new Date()),
         isWeekend: isSaturday || isSunday,
         isSaturday,

--- a/src/mixins/navMixin.vue
+++ b/src/mixins/navMixin.vue
@@ -437,9 +437,7 @@ export default {
       const view = this.ucFirst(this.view)
 
       this.navElements = [
-        this.getElementsFromSlot('beforeDateInput'),
         this.getInputField(),
-        this.getElementsFromSlot('afterDateInput'),
         this.getElementsFromSlot('beforeCalendarHeader'),
         this.getElementsFromSlot(`beforeCalendarHeader${view}`),
         this.getElementsFromHeader(),

--- a/src/mixins/navMixin.vue
+++ b/src/mixins/navMixin.vue
@@ -209,17 +209,17 @@ export default {
       return this.getFocusableElements(picker.children[index])
     },
     /**
-     * Returns an array of all HTML elements which should be focus-trapped in the header
-     * @returns {Array}   An array of HTML elements
+     * Returns an array of all HTMLButtonElements which should be focus-trapped in the header
+     * @returns {Array}   An array of HTMLButtonElements
      */
     getElementsFromHeader() {
-      const view = this.ucFirst(this.view)
-      const beforeCalendarSlotName = `beforeCalendarHeader${view}`
-      const picker = this.$refs.picker.$el
-      const index = this.hasSlot(beforeCalendarSlotName) ? 1 : 0
-      const fragment = picker.children[index]
+      if (!this.$refs.picker.$refs.pickerHeader) {
+        return []
+      }
+      const header = this.$refs.picker.$refs.pickerHeader.$el
+      const navNodeList = header.querySelectorAll('button:enabled')
 
-      return this.showHeader ? this.getFocusableElements(fragment) : []
+      return [...Array.prototype.slice.call(navNodeList)]
     },
     /**
      * Returns an array of focusable elements in a given HTML fragment

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -148,10 +148,22 @@ const utils = {
   /**
    * Check if date1 is equivalent to date2, without comparing the time
    * @see https://stackoverflow.com/a/6202196/4455925
-   * @param {Date} date1
-   * @param {Date} date2
+   * @param {Date|null} date1
+   * @param {Date|null} date2
    */
+  // eslint-disable-next-line complexity
   compareDates(date1, date2) {
+    if (date1 === null && date2 === null) {
+      return true
+    }
+
+    if (
+      (date1 !== null && date2 === null) ||
+      (date2 !== null && date1 === null)
+    ) {
+      return false
+    }
+
     const d1 = new Date(date1.valueOf())
     const d2 = new Date(date2.valueOf())
 

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -267,7 +267,6 @@ describe('Datepicker shallowMounted', () => {
     })
 
     expect(wrapperTemp.vm.selectedDate).toEqual(null)
-    expect(wrapperTemp.emitted('input')).toBeTruthy()
 
     wrapperTemp.destroy()
   })

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -255,20 +255,17 @@ describe('Datepicker shallowMounted', () => {
     expect(wrapper.emitted('changed-decade')).toBeTruthy()
   })
 
-  it('clears date on default date disabled', async () => {
+  it('clears the date when it is disabled', async () => {
     const someDate = new Date('2021-01-15')
-    const wrapperTemp = shallowMount(Datepicker, {
-      propsData: {
-        value: someDate,
-        disabledDates: {
-          to: addDays(someDate, 1),
-        },
+
+    await wrapper.setProps({
+      value: someDate,
+      disabledDates: {
+        to: addDays(someDate, 1),
       },
     })
 
-    expect(wrapperTemp.vm.selectedDate).toEqual(null)
-
-    wrapperTemp.destroy()
+    expect(wrapper.vm.selectedDate).toBeNull()
   })
 
   it('sets the transition correctly', async () => {


### PR DESCRIPTION
This excludes any focusable elements in the `beforeDateInput`, `afterDateInput`, `prevIntervalBtn`, or `nextIntervalBtn` slots from being focus-trapped. Having revisited this, I think the only elements which should be focus-trapped are: 

1. the input field (when `typeable`)
2. the buttons in the `PickerHeader` (unless of course they're disabled)
3. the `tabbableCell`
4. any focusable elements that may be present within slot content of the `popup` element

The PR also removes the need to keep track of all focusable elements in the datepicker (i.e. the `allElements` property in `navMixin`). favouring instead 1) to rely on the `isActive` property to determine whether any elements are focused (in `handleClickOutside`) and 2) to calculate the first or last focusable elements by considering only elements in the `popup` (when tabbing away from an inline datepicker). 
