### PR TITLE
Fix UTC issues

### DIFF
--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -336,7 +336,7 @@ export default {
         isHighlightStart: this.isHighlightStart(dObj),
         isHighlightEnd: this.isHighlightEnd(dObj),
         isOpenDate: utils.compareDates(dObj, this.openDate),
-        isToday: utils.compareDates(dObj, new Date()),
+        isToday: utils.compareDates(dObj, this.todayDate),
         isWeekend: isSaturday || isSunday,
         isSaturday,
         isSunday,

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -114,10 +114,10 @@ export default {
       const days = []
       const daysInCalendar =
         this.daysFromPrevMonth + this.daysInMonth + this.daysFromNextMonth
-      const dObj = this.firstCellDate()
+      const dObj = this.firstDayCellDate()
 
       for (let i = 0; i < daysInCalendar; i += 1) {
-        days.push(this.makeDay(i, dObj))
+        days.push(this.makeDay(dObj))
         this.utils.setDate(dObj, this.utils.getDate(dObj) + 1)
       }
 
@@ -248,24 +248,12 @@ export default {
   methods: {
     /**
      * Set up a new date object to the first day of the current 'page'
-     * @return Date
+     * @return {Date}
      */
-    firstCellDate() {
-      const d = this.pageDate
+    firstDayCellDate() {
+      const pageDate = new Date(this.pageDate)
 
-      const firstOfMonth = this.useUtc
-        ? new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1))
-        : new Date(
-            d.getFullYear(),
-            d.getMonth(),
-            1,
-            d.getHours(),
-            d.getMinutes(),
-          )
-
-      return new Date(
-        firstOfMonth.setDate(firstOfMonth.getDate() - this.daysFromPrevMonth),
-      )
+      return new Date(this.utils.setDate(pageDate, 1 - this.daysFromPrevMonth))
     },
     /**
      * Whether a day is disabled
@@ -326,28 +314,29 @@ export default {
     },
     /**
      * Defines the objects within the days array
-     * @param  {id}  id
-     * @param  {Date}  dObj
+     * @param  {Date} dObj
      * @return {Object}
      */
     // eslint-disable-next-line complexity
-    makeDay(id, dObj) {
+    makeDay(dObj) {
+      const { utils } = this
+      const dayOfWeek = utils.getDay(dObj)
       const isNextMonth = dObj >= this.firstOfNextMonth
       const isPreviousMonth = dObj < this.pageDate
-      const isSaturday = this.utils.getDay(dObj) === 6
-      const isSunday = this.utils.getDay(dObj) === 0
+      const isSaturday = dayOfWeek === 6
+      const isSunday = dayOfWeek === 0
       const showDate = this.showEdgeDates || !(isPreviousMonth || isNextMonth)
 
       return {
-        date: showDate ? this.utils.getDate(dObj) : '',
+        date: showDate ? utils.getDate(dObj) : '',
         timestamp: dObj.valueOf(),
         isSelected: this.isSelectedDate(dObj),
         isDisabled: showDate ? this.isDisabledDate(dObj) : true,
         isHighlighted: this.isHighlightedDate(dObj),
         isHighlightStart: this.isHighlightStart(dObj),
         isHighlightEnd: this.isHighlightEnd(dObj),
-        isOpenDate: this.utils.compareDates(dObj, this.openDate),
-        isToday: this.utils.compareDates(dObj, new Date()),
+        isOpenDate: utils.compareDates(dObj, this.openDate),
+        isToday: utils.compareDates(dObj, new Date()),
         isWeekend: isSaturday || isSunday,
         isSaturday,
         isSunday,

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -75,33 +75,20 @@ export default {
      * @return {Array}
      */
     cells() {
-      const d = this.pageDate
+      const { utils } = this
       const months = []
-      // set up a new date object to the beginning of the current 'page'
-      const dObj = this.useUtc
-        ? new Date(Date.UTC(d.getUTCFullYear(), 0, d.getUTCDate()))
-        : new Date(
-            d.getFullYear(),
-            0,
-            d.getDate(),
-            d.getHours(),
-            d.getMinutes(),
-          )
-
-      const todayMonth = new Date(
-        this.utils.setDate(this.utils.getNewDateObject(), 1),
-      )
+      const dObj = this.firstMonthCellDate()
 
       for (let i = 0; i < 12; i += 1) {
         months.push({
-          month: this.utils.getMonthName(i, this.translation.months),
+          month: utils.getMonthName(i, this.translation.months),
           timestamp: dObj.valueOf(),
           isDisabled: this.isDisabledMonth(dObj),
           isOpenDate: this.isOpenMonth(dObj),
           isSelected: this.isSelectedMonth(dObj),
-          isToday: this.utils.compareDates(dObj, todayMonth),
+          isToday: this.isTodayMonth(dObj),
         })
-        this.utils.setMonth(dObj, this.utils.getMonth(dObj) + 1)
+        utils.setMonth(dObj, utils.getMonth(dObj) + 1)
       }
 
       return months
@@ -136,6 +123,15 @@ export default {
     },
   },
   methods: {
+    /**
+     * Set up a new date object to the first month of the current 'page'
+     * @return {Date}
+     */
+    firstMonthCellDate() {
+      const pageDate = new Date(this.pageDate)
+
+      return new Date(this.utils.setMonth(pageDate, 0))
+    },
     /**
      * Whether a month is disabled
      * @param {Date} date
@@ -176,6 +172,17 @@ export default {
         year === this.utils.getFullYear(this.selectedDate) &&
         month === this.utils.getMonth(this.selectedDate)
       )
+    },
+    /**
+     * Whether the date has the same month and year as today's date
+     * @param {Date} date
+     * @return {Boolean}
+     */
+    isTodayMonth(date) {
+      const { utils } = this
+      const todayMonth = new Date(utils.setDate(utils.getNewDateObject(), 1))
+
+      return utils.compareDates(date, todayMonth)
     },
   },
 }

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -180,7 +180,7 @@ export default {
      */
     isTodayMonth(date) {
       const { utils } = this
-      const todayMonth = new Date(utils.setDate(utils.getNewDateObject(), 1))
+      const todayMonth = new Date(utils.setDate(this.todayDate, 1))
 
       return utils.compareDates(date, todayMonth)
     },

--- a/src/components/PickerYear.vue
+++ b/src/components/PickerYear.vue
@@ -77,35 +77,21 @@ export default {
      * Sets an array with all years to show this decade (or yearRange)
      * @return {Array}
      */
-    // eslint-disable-next-line complexity,max-statements
     cells() {
-      const d = this.pageDate
+      const { utils } = this
       const years = []
-      const year = this.useUtc
-        ? Math.floor(d.getUTCFullYear() / this.yearRange) * this.yearRange
-        : Math.floor(d.getFullYear() / this.yearRange) * this.yearRange
-      // set up a new date object to the beginning of the current 'page'
-      const dObj = this.useUtc
-        ? new Date(Date.UTC(year, d.getUTCMonth(), d.getUTCDate()))
-        : new Date(
-            year,
-            d.getMonth(),
-            d.getDate(),
-            d.getHours(),
-            d.getMinutes(),
-          )
-      const todayYear = this.utils.getFullYear(this.utils.getNewDateObject())
+      const dObj = this.firstYearCellDate()
 
       for (let i = 0; i < this.yearRange; i += 1) {
         years.push({
-          year: this.utils.getFullYear(dObj),
+          year: utils.getFullYear(dObj),
           timestamp: dObj.valueOf(),
           isDisabled: this.isDisabledYear(dObj),
           isOpenDate: this.isOpenYear(dObj),
           isSelected: this.isSelectedYear(dObj),
-          isToday: dObj.getFullYear() === todayYear,
+          isToday: this.isTodayYear(dObj),
         })
-        this.utils.setFullYear(dObj, this.utils.getFullYear(dObj) + 1)
+        utils.setFullYear(dObj, utils.getFullYear(dObj) + 1)
       }
 
       // Fill any remaining cells with blanks to position trailing cells correctly when rtl
@@ -164,6 +150,19 @@ export default {
   },
   methods: {
     /**
+     * Set up a new date object to the first year of the current 'page'
+     * @return {Date}
+     */
+    firstYearCellDate() {
+      const { utils } = this
+      const pageDate = new Date(this.pageDate)
+      const firstYear =
+        Math.floor(utils.getFullYear(pageDate) / this.yearRange) *
+        this.yearRange
+
+      return new Date(utils.setFullYear(pageDate, firstYear))
+    },
+    /**
      * Whether a year is disabled
      * @param {Date} date
      * @return {Boolean}
@@ -198,6 +197,17 @@ export default {
       return (
         this.selectedDate && year === this.utils.getFullYear(this.selectedDate)
       )
+    },
+    /**
+     * Whether the date has the same year as today's date
+     * @param {Date} date
+     * @return {Boolean}
+     */
+    isTodayYear(date) {
+      const { utils } = this
+      const todayYear = utils.getFullYear(utils.getNewDateObject())
+
+      return date.getFullYear() === todayYear
     },
   },
 }

--- a/src/components/PickerYear.vue
+++ b/src/components/PickerYear.vue
@@ -205,9 +205,9 @@ export default {
      */
     isTodayYear(date) {
       const { utils } = this
-      const todayYear = utils.getFullYear(utils.getNewDateObject())
+      const todayYear = utils.getFullYear(this.todayDate)
 
-      return date.getFullYear() === todayYear
+      return utils.getFullYear(date) === todayYear
     },
   },
 }

--- a/src/mixins/pickerMixin.vue
+++ b/src/mixins/pickerMixin.vue
@@ -113,6 +113,9 @@ export default {
     pageYear() {
       return this.utils.getFullYear(this.pageDate)
     },
+    todayDate() {
+      return this.utils.getNewDateObject()
+    },
   },
   methods: {
     /**

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -5,15 +5,22 @@ import en from '~/locale/translations/en'
  * @param {String} dateStr
  * @param {String} formatStr
  * @param {Object} translation
+ * @param {Number} currentYear
  * @param {String} time
  * @return String
  */
 // eslint-disable-next-line complexity,max-statements
-const getParsableDate = ({ dateStr, formatStr, translation, time }) => {
+const getParsableDate = ({
+  dateStr,
+  formatStr,
+  translation,
+  currentYear,
+  time,
+}) => {
   const splitter = formatStr.match(/-|\/|\s|\./) || ['-']
   const df = formatStr.split(splitter[0])
   const ds = dateStr.split(splitter[0])
-  const ymd = [new Date().getFullYear().toString(), '01', '01']
+  const ymd = [currentYear.toString(), '01', '01']
 
   for (let i = 0; i < df.length; i += 1) {
     if (/yyyy/i.test(df[i])) {
@@ -341,6 +348,7 @@ const utils = {
       dateStr,
       formatStr: format,
       translation,
+      currentYear: this.getFullYear(new Date()),
       time: this.getTime(),
     })
     const parsedDate = Date.parse(parseableDate)


### PR DESCRIPTION
Turns out there were a couple of issues with UTC dates:

1. Today's date/month/year may not be highlighted correctly as we are always comparing the cells' date with a local date. We can avoid this by using `getNewDateObject()` which takes into account the value of `use-utc`.

2. When parsing a typed date on 1st January, there is a remote chance of getting the wrong default year as we're using `new Date.getFullYear()` instead of the UTC-sensitive equivalent.

This PR also tidies up the code that generates the cells in the various pickers by relying on the fact that `pageDate` will be UTC-sensitive. 