### PR TITLE
Exclude non-tabbable elements from focus trap

### DIFF
--- a/src/mixins/navMixin.vue
+++ b/src/mixins/navMixin.vue
@@ -228,7 +228,7 @@ export default {
       }
 
       const navNodeList = fragment.querySelectorAll(
-        'button:enabled, [href], input:not([type=hidden]), select:enabled, textarea:enabled, [tabindex]:not([tabindex="-1"])',
+        'button:enabled:not([tabindex="-1"]), [href]:not([tabindex="-1"]), input:not([tabindex="-1"]):not([type=hidden]), select:enabled:not([tabindex="-1"]), textarea:enabled:not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])',
       )
 
       return [...Array.prototype.slice.call(navNodeList)]


### PR DESCRIPTION
This fixes an issue where elements with `tabindex="-1"` were still being added to the array of focus-trapped elements. But please see #182 first to see in which order to merge the PRs. 