### PR TITLE
Close calendar on selecting a date when `typeable` and `show-calendar-on-focus` are true

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -129,13 +129,12 @@ export default {
     },
     isOpen(isOpen, wasOpen) {
       this.$nextTick(() => {
-        if (this.showCalendarOnFocus) {
-          if (isOpen) {
-            this.shouldToggleOnFocus = false
-          }
+        if (isOpen && this.showCalendarOnFocus) {
           if (wasOpen && !this.isInputFocused) {
             this.shouldToggleOnFocus = true
+            return
           }
+          this.shouldToggleOnFocus = false
         }
       })
     },

--- a/src/mixins/navMixin.vue
+++ b/src/mixins/navMixin.vue
@@ -228,7 +228,7 @@ export default {
       }
 
       const navNodeList = fragment.querySelectorAll(
-        'button:enabled, [href], input:not([type=hidden]), select:enabled, textarea:enabled, [tabindex]:not([tabindex="-1"])',
+        'button:enabled:not([tabindex="-1"]), [href]:not([tabindex="-1"]), input:not([tabindex="-1"]):not([type=hidden]), select:enabled:not([tabindex="-1"]), textarea:enabled:not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])',
       )
 
       return [...Array.prototype.slice.call(navNodeList)]


### PR DESCRIPTION
This fixes a bug where the calendar was re-opening immediately after selecting a date.