### PR TITLE
Display the initial value of a `typeable` calendar correctly

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -138,10 +138,13 @@ export default {
         }
       })
     },
-    selectedDate(selectedDate) {
-      if (this.typeable) {
-        this.typedDate = this.formatDate(selectedDate)
-      }
+    selectedDate: {
+      immediate: true,
+      handler(selectedDate) {
+        if (this.typeable) {
+          this.typedDate = this.formatDate(selectedDate)
+        }
+      },
     },
   },
   mounted() {

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -258,6 +258,29 @@ describe('Datepicker mounted', () => {
   })
 })
 
+describe('Datepicker mounted with a default value', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(Datepicker, {
+      propsData: {
+        typeable: true,
+        value: new Date(new Date(2000, 0, 1).setHours(0, 0, 0, 0)),
+      },
+    })
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  it('displays a date passed in as a default value', async () => {
+    const input = wrapper.find('input')
+
+    expect(input.element.value).toEqual('01 Jan 2000')
+  })
+})
+
 describe('Datepicker mounted with showCalendarOnFocus', () => {
   let wrapper
 


### PR DESCRIPTION
This fixes #189. Basically, we need to invoke the `selectedDate` watcher on `DateInput.vue` immediately.